### PR TITLE
Add support for Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # ignore all pyc files
 *.pyc
+*.c
+*.o
+*.dll
 *~
 .vscode/settings.json
 examples/*/NRN*/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SNNAP2NEURON
-Automatically translate SNNAP simulations to Neuron.
+Automatically translate SNNAP simulations to NEURON.
 
 ## Usage
 
@@ -7,16 +7,16 @@ Automatically translate SNNAP simulations to Neuron.
 
 2. Run `readS.py -i [.smu file you wish to translate]`
 
-In the directory of the SNNAP project you translated, a new folder named `NRNModel_[name]` will be created, containing the necesary `.hoc` files to replicated the results of the SNNAP simulation in Neuron.
+In the directory of the SNNAP project you translated, a new folder named `NRNModel_[name]` will be created, containing the necesary `.hoc` files to replicated the results of the SNNAP simulation in NEURON.
 
-All the necessary `.mod` files will be found in the directory of this project: `SNNAP2NERON/utilityfiles/snnap_modfiles`
+All the necessary `.mod` files will be found in the directory of this project: `SNNAP2NEURON/utilityFiles/snnap_modFiles`.
 
-1. Compile the `*.mod` files 
+1. Compile the `*.mod` files
 
     - [Windows](https://www.neuron.yale.edu/neuron/static/docs/nmodl/mswin.html)
     - [Mac](https://www.neuron.yale.edu/neuron/static/docs/nmodl/macos.html)
     - [Linux/Unix](https://www.neuron.yale.edu/neuron/static/docs/nmodl/unix.html)
 
-1. Run `NRNModel_[name]/sim_[name].hoc` with Neuron.
+2. Run `NRNModel_[name]/sim_[name].hoc` with NEURON.
 
 Your SNNAP results should be reproduced. For help visualizing them, check `UseExample.ipynb`.

--- a/chemicalSynapse.py
+++ b/chemicalSynapse.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import re
 import os
 import util
@@ -31,13 +33,13 @@ class ChemSynapse():
         self.synType = synType
         self.color = color
 
-        # parameters from .cs file        
+        # parameters from .cs file
         self.iCSType = ""
         self.fAtFileName = ""
         self.R = ""
         self.g = ""
         self.E = ""
-        
+
         # parameters from .fAT file
         self.fATType = ""
         self.fAT_a = ""
@@ -50,14 +52,14 @@ class ChemSynapse():
         self.XtFileName = ""
         self.PSM_ud = ""
         self.PSM_ur = ""
-        
+
         self.readCSFile()
         if self.iCSType == '1':
             self.readfATFile()
             if self.ATType == '3':
                 self.readXtFile()
                 pass
-                
+
 
     def readXtFile(self):
         """
@@ -79,14 +81,14 @@ class ChemSynapse():
                         self.extractPSM(i+1, lineArr)
                 i = i+1
 
-                
+
     def extractPSM(self, i, lineArr):
         """
         since PSM has only one option
         """
         self.PSM_ud = self.findNextFeature(i+1, lineArr, feature="ud")
         self.PSM_ur = self.findNextFeature(i+1, lineArr, feature="ur")
-    
+
 
     def readfATFile(self):
         """
@@ -112,9 +114,9 @@ class ChemSynapse():
                         self.fAT_b = self.findNextFeature(i+1, lineArr, feature="b")
                 if re.search("^At", line[0]) is not None:
                     self.extractAt(i, lineArr)
-                    
+
                 i = i+1
-                
+
     def extractAt(self, i, lineArr):
         self.ATType = lineArr[i+1][0]
         if self.ATType == '1':
@@ -123,7 +125,7 @@ class ChemSynapse():
         if self.ATType == '3':
             self.XtFileName = lineArr[i+2][0]
             self.At_u1 = lineArr[i+3][0]
-            
+
     def readCSFile(self):
         """
         read SNNAP chemical synapse (.cs) file
@@ -131,7 +133,7 @@ class ChemSynapse():
         fileName = os.path.join(self.filePath,self.fileName)
         with open(fileName) as f:
             self.text = f.read()
-            print "Reading chemical synapse file : ", fileName
+            print("Reading chemical synapse file : ", fileName)
 
             # extract useful lines from the the text
             lineArr = util.cleanupFileText(self.text)
@@ -155,16 +157,15 @@ class ChemSynapse():
             self.g = self.findNextFeature(i, lineArr, feature="g")
             self.E = self.findNextFeature(i, lineArr, feature="E")
         else :
-            print "WARNING: Only chemical synapses of type 1(Ics: 1) are supported!!!"
-            
+            print("WARNING: Only chemical synapses of type 1(Ics: 1) are supported!!!")
+
     def findNextFeature(self, i, lineArr, feature=""):
         if feature == "":
             return None
-        
+
         j = i+1
         if j >= len(lineArr):
             return None
         while len(lineArr[j]) > 1 and re.search(feature, lineArr[j][1]) is None:
             j = j+1
         return lineArr[j][0]
-

--- a/fbr.py
+++ b/fbr.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import os
 import re
@@ -37,13 +39,13 @@ class FBR():
         read fBR  file
         """
         filename = os.path.join(self.filePath,self.fileName)
-        print "FBR FIle", filename
+        print("FBR FIle", filename)
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading fBR file : ", filename
+            print("Reading fBR file : ", filename)
             lineArr = util.cleanupFileText(self.text)
-            
+
             i = 0
             while i< len(lineArr):
                 line = lineArr[i]
@@ -67,8 +69,8 @@ class FBR():
 
         BRType = lineArr[i][0]
         if BRType == '1':
-            print "WARNING!! Ion pool concentration type 1 is not supported yet"
-            print "Exiting..."
+            print("WARNING!! Ion pool concentration type 1 is not supported yet")
+            print("Exiting...")
             sys.exit(1)
         elif BRType == '2' or BRType == '3':
             BR_a = util.findNextFeature(i, lineArr, "a")
@@ -85,9 +87,8 @@ class FBR():
         """
         fBRType = lineArr[i][0]
         if fBRType == '3':
-            print "WARNING!! Modulation by regulator type 3 is not supported yet"
-            print "Exiting..."
+            print("WARNING!! Modulation by regulator type 3 is not supported yet")
+            print("Exiting...")
             sys.exit(1)
 
         return fBRType
-

--- a/ion.py
+++ b/ion.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import os
 import re
@@ -44,9 +46,9 @@ class IonPool():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading ion file : ", filename
+            print("Reading ion file : ", filename)
             lineArr = util.cleanupFileText(self.text)
-            
+
             i = 0
             while i< len(lineArr):
                 line = lineArr[i]
@@ -70,10 +72,10 @@ class IonPool():
 
         iType = lineArr[i][0]
         if iType == '1':
-            print "WARNING!! Ion pool concentration type 1 is not supported yet"
-            print "Exiting..."
+            print("WARNING!! Ion pool concentration type 1 is not supported yet")
+            print("Exiting...")
             sys.exit(1)
-            
+
         elif iType == '2':
             i_k1 = util.findNextFeature(i, lineArr, "K1")
             i_k2 = util.findNextFeature(i, lineArr, "K2")
@@ -108,13 +110,13 @@ class ConductanceByIon():
         read fBR  file
         """
         filename = os.path.join(self.filePath,self.fileName)
-        print "FBR FIle", filename
+        print("FBR FIle", filename)
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading fBR file : ", filename
+            print("Reading fBR file : ", filename)
             lineArr = util.cleanupFileText(self.text)
-            
+
             i = 0
             while i< len(lineArr):
                 line = lineArr[i]
@@ -138,10 +140,10 @@ class ConductanceByIon():
 
         BRType = lineArr[i][0]
         if BRType == '1':
-            print "WARNING!! Ion pool concentration type 1 is not supported yet"
-            print "Exiting..."
+            print("WARNING!! Ion pool concentration type 1 is not supported yet")
+            print("Exiting...")
             sys.exit(1)
-            
+
         elif BRType == '2' or BRType == '3':
             BR_a = util.findNextFeature(i, lineArr, "a")
         elif BRType == '4':
@@ -149,7 +151,7 @@ class ConductanceByIon():
             BR_a = lineArr[i+1][0]
 
         return BRType, BR_a
-    
+
     # def extractBR(self, i, lineArr):
     #     """
     #     read and return parameters related to regulaion of conductances by ion
@@ -159,10 +161,10 @@ class ConductanceByIon():
 
     #     BRType = lineArr[i][0]
     #     if BRType in ['1', '4']:
-    #         print "WARNING!! Ion pool concentration type 1 or 4 not supported yet"
-    #         print "Exiting..."
+    #         print("WARNING!! Ion pool concentration type 1 or 4 not supported yet")
+    #         print("Exiting...")
     #         sys.exit(1)
-            
+
     #     else:
     #         BR_a = util.findNextFeature(i, lineArr, "a")
     #     return BRType, BR_a
@@ -174,9 +176,8 @@ class ConductanceByIon():
         """
         fBRType = lineArr[i][0]
         if fBRType == '3':
-            print "WARNING!! Modulation by regulator type 3 is not supported yet"
-            print "Exiting..."
+            print("WARNING!! Modulation by regulator type 3 is not supported yet")
+            print("Exiting...")
             sys.exit(1)
 
         return fBRType
-

--- a/network.py
+++ b/network.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import re
 import os
 import util
@@ -40,7 +42,7 @@ class ElecSynapse():
         filename = os.path.join(self.filePath,self.fileName)
         with open(filename) as f:
             self.text = f.read()
-            print "Reading electrical coupling file : ", filename
+            print("Reading electrical coupling file : ", filename)
             # extract useful lines from the the text
             lineArr = util.cleanupFileText(self.text)
 
@@ -73,7 +75,7 @@ class Network():
         filename = os.path.join(self.filePath,self.fileName)
         with open(filename) as f:
             self.text = f.read()
-            print "Reading network file : ", filename
+            print("Reading network file : ", filename)
 
             # extract useful lines from the the text
             lineArr = util.cleanupFileText(self.text)
@@ -85,7 +87,7 @@ class Network():
                 if len(line) < 2:
                     i = i+1
                     continue
-                
+
                 if line[0] == "LIST_NEURONS:":
                     i = self.extractNeurons(i+1, lineArr)
 
@@ -102,14 +104,14 @@ class Network():
         """
         TODO
         """
-        print "Reading Modulatory synapses"
+        print("Reading Modulatory synapses")
         while lineArr[i][0] != "END":
             i = i+1
-        print "Done reading Modulatory synapses"
+        print("Done reading Modulatory synapses")
         return i+1
-    
+
     def extractElecSynapses(self, i, lineArr):
-        print "Reading electrical coupling"
+        print("Reading electrical coupling")
         while lineArr[i][0] != "END":
             if re.search("postsynaptic", lineArr[i][1]) is not None:
                 postSyn = lineArr[i][0]
@@ -118,11 +120,11 @@ class Network():
                 elecSynapseColor = self.findNextFeature(i, lineArr, feature="Color")
                 self.elecSyns.append(ElecSynapse(postSyn, preSyn, elecSynapseFilename, elecSynapseColor, self.filePath))
             i = i+1
-        print "Found", len(self.elecSyns), "electrical synapses."
+        print("Found", len(self.elecSyns), "electrical synapses.")
         return i+1
 
     def extractChemSynapses(self, i, lineArr):
-        print "Reading chemical synapses in .ntw file"
+        print("Reading chemical synapses in .ntw file")
         while lineArr[i][0] != "END":
             if re.search("postsynaptic", lineArr[i][1]) is not None:
                 postSyn = lineArr[i][0]
@@ -132,12 +134,12 @@ class Network():
                 chemSynapseColor = self.findNextFeature(i, lineArr, feature="Color")
                 self.chemSyns.append(ChemSynapse(postSyn, preSyn, chemSynapseType, chemSynapseFilename, chemSynapseColor, self.filePath))
             i = i+1
-        print "Found", len(self.chemSyns), "chemical synapses."
+        print("Found", len(self.chemSyns), "chemical synapses.")
         return i+1
 
     def findNextFeature(self, i, lineArr, feature=""):
         if feature == "":
-            return None        
+            return None
         j = i+1
         if j >= len(lineArr):
             return None
@@ -145,13 +147,13 @@ class Network():
             #while re.search(feature, lineArr[j][1]) is None:
             j = j+1
         return lineArr[j][0]
-    
+
     def extractNeurons(self, i, lineArr):
         """
-        read neuron name, filename, and color from .ntw file and create a Neuron object 
+        read neuron name, filename, and color from .ntw file and create a Neuron object
         for each of the read neurons and store them in dictionary 'self.neurons'
         """
-        print "Reading neurons in .ntw file"
+        print("Reading neurons in .ntw file")
         while (lineArr[i][0] != "END"):
             if lineArr[i][1] == "Neuron's name":
                 nName = lineArr[i][0]
@@ -160,9 +162,9 @@ class Network():
                 self.neurons[nName] = Neuron(nName, nFilename, nColor, self.filePath)
 
             i = i+1
-        print "Found", len(self.neurons.keys()), "nerons."
+        print("Found", len(self.neurons.keys()), "nerons.")
         return i+1
-        
+
     def findNextFilename(self, i, lineArr):
         j = i+1
 
@@ -170,11 +172,10 @@ class Network():
             j = j+1
         return lineArr[j][0]
 
-        
+
     def findNextColor(self, i, lineArr):
         j = i+1
 
         while(lineArr[j][1] != "Color Name"):
             j = j+1
         return lineArr[j][0]
-            

--- a/neuron.py
+++ b/neuron.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import re
 import os
 import util
@@ -49,7 +51,7 @@ class Neuron():
         # regulation of vdg by sm pools
         self.condBySM = []
         self.readNeuronFile()
-        
+
     def readNeuronFile(self):
         """
         read .neu file
@@ -58,7 +60,7 @@ class Neuron():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading neuron file : ", filename
+            print("Reading neuron file : ", filename)
             lineArr = util.cleanupFileText(self.text)
 
             i = 0
@@ -78,10 +80,10 @@ class Neuron():
 
                 elif re.search("CM", line[0]) is not None:
                     self.cm = self.extractNeuronsFeature(i+1, line[0])
-                    
+
                 elif re.search("^MEM_AREA", line[0]) is not None:
                     self.memAreaType = lineArr[i+1][0]
-                    
+
                 elif line[0] == "CONDUCTANCES:":
                     i = self.extractConductance(i+1, lineArr)
                 elif line[0] == "LIST_ION:":
@@ -100,7 +102,7 @@ class Neuron():
         """
         read and store regulation of voltage dependent conductances by sm pools
         """
-        print "Reading regulation of voltage dependent conductances by sm pools"
+        print("Reading regulation of voltage dependent conductances by sm pools")
         while lineArr[i][0] != "END":
             if re.search("Name of Conductance", lineArr[i][1]) is not None:
                 condName = lineArr[i][0].replace('(', '_').replace(')', '_')
@@ -115,7 +117,7 @@ class Neuron():
         """
         read and store regulation of voltage dependent conductances by ion pools
         """
-        print "Reading regulation of voltage dependent conductances by ion pools"
+        print("Reading regulation of voltage dependent conductances by ion pools")
         while lineArr[i][0] != "END":
             if re.search("Name of Conductance", lineArr[i][1]) is not None:
                 condName = lineArr[i][0].replace('(', '_').replace(')', '_')
@@ -130,7 +132,7 @@ class Neuron():
         """
         read list of currents that contribute to ion pools
         """
-        print "Reading list of currents that contribute to ion pools"
+        print("Reading list of currents that contribute to ion pools")
         while lineArr[i][0] != "END":
             if re.search("Name of Conductance", lineArr[i][1]) is not None:
                 condName = lineArr[i][0].replace('(', '_').replace(')', '_')
@@ -139,13 +141,13 @@ class Neuron():
                 self.curr2Ions.append(Current2Ion(condName, ionName, color))
             i = i+1
         return i
-    
+
     def extractSMPools(self, i, lineArr):
         """
         read and store second messenger pools from
         .neu files
         """
-        print "Reading sm pools"
+        print("Reading sm pools")
         while lineArr[i][0] != "END":
             if re.search("Name of SM", lineArr[i][1]) is not None:
                 smName = lineArr[i][0]
@@ -154,13 +156,13 @@ class Neuron():
                 self.smPools[smName] = SMPool(self.filePath, smFileName, smColor)
             i = i+1
         return i
-    
+
     def extractIonPools(self, i, lineArr):
         """
         read and store ion pools from
         .neu files
         """
-        print "Reading ion pools"
+        print("Reading ion pools")
         while lineArr[i][0] != "END":
             if re.search("Name of Ion", lineArr[i][1]) is not None:
                 ionName = lineArr[i][0]
@@ -175,7 +177,7 @@ class Neuron():
         read and store leak, Na, K, conductance filenames(*.vdg) and color from
         .neu files
         """
-        print "Reading conductances"
+        print("Reading conductances")
         while lineArr[i][0] != "END":
             if re.search("Name of conductance", lineArr[i][1]) is not None:
                 # vdg names sometimes had paranthesis!
@@ -183,7 +185,7 @@ class Neuron():
                 vdgFileName = lineArr[i+1][0]
                 vdgColor = lineArr[i+2][0]
                 self.vdgs[vdgName] = VDConductance(self.filePath, vdgFileName, vdgColor)
-                
+
             i = i+1
         return i
 

--- a/nrnModFile.py
+++ b/nrnModFile.py
@@ -136,7 +136,7 @@ class NRNModFile():
                 modInj_start = str(1000* float(modInj.start))
                 modInj_stop = str(1000* float(modInj.stop))
                 # convert units of concentraion
-                # (modulator magnitude is in the same units in both SNNAP and neuron)
+                # (modulator magnitude is in the same units in both SNNAP and NEURON)
                 modInj_mag = str(1.0* float(modInj.magnitude))
 
                 # set up sm modulation

--- a/nrnModel.py
+++ b/nrnModel.py
@@ -32,7 +32,7 @@ class NRNModel():
         self.useNrnPas = False
 
         self.neuronlist = {}
-        self.neutonFiles = []
+        self.neuronFiles = []
         self.chemSynFiles = []
         self.ElecCouplingFile = ""
         self.treatmentFile = None
@@ -273,7 +273,7 @@ class NRNModel():
             mf.write("load_file(\"nrngui.hoc\")\n\n")
 
             mf.write("// create neurons\n")
-            for nfile in self .neutonFiles:
+            for nfile in self .neuronFiles:
                 mf.write("load_file(\"" +nfile+ "\")\n")
             mf.write("\n")
 
@@ -352,7 +352,7 @@ class NRNModel():
             with open(nFileName, "w") as nf:
 
                 # append file name to the neuron filelist
-                self.neutonFiles.append(nf_local)
+                self.neuronFiles.append(nf_local)
 
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")

--- a/nrnModel.py
+++ b/nrnModel.py
@@ -258,9 +258,9 @@ class NRNModel():
         with open(rFileName, "w") as rf:
 
             rf.write("This is an automatically generated directory.\n")
-            rf.write("These scripts will allow you to recreate the results of "+self.simName+".smu in Neuron\n")
+            rf.write("These scripts will allow you to recreate the results of "+self.simName+".smu in NEURON\n")
             rf.write("Before running them, conpile the .mod files found in SNNAP2NERON/utilityfiles/snnap_modfiles\n")
-            rf.write("Then simply run file in this directory which is named sim_"+self.simName+".hoc in Neuron\n")
+            rf.write("Then simply run file in this directory which is named sim_"+self.simName+".hoc in NEURON\n")
             rf.write("\n")
             rf.write("More info here: https://github.com/madawa87/SNNAP2NEURON/tree/master")
 
@@ -335,7 +335,7 @@ class NRNModel():
 
         if not os.path.isdir(self.nrnDirPath + os.sep + self.nrnDirName):
             os.mkdir(self.nrnDirPath + os.sep + self.nrnDirName)
-            print("Neuron model is located in ", self.nrnDirPath+ os.sep + self.nrnDirName)
+            print("NEURON model is located in ", self.nrnDirPath+ os.sep + self.nrnDirName)
 
     def writeNeurons(self, sSim):
         """
@@ -452,7 +452,7 @@ class NRNModel():
                     nf.write("\n")
 
     def write_ActF_rateConstant(self, file, vdgObj, ivd):
-        # in SNNAP time derivatives are also in seconds. to convert them to Neuron time derivatives
+        # in SNNAP time derivatives are also in seconds. to convert them to NEURON time derivatives
         # must be divided by 1000.0
         lj = self.lJust1
         afType = ivd.mType

--- a/nrnModel.py
+++ b/nrnModel.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import re
 import os
@@ -28,7 +30,7 @@ class NRNModel():
 
         # use neuron pas
         self.useNrnPas = False
-        
+
         self.neuronlist = {}
         self.neutonFiles = []
         self.chemSynFiles = []
@@ -37,7 +39,7 @@ class NRNModel():
 
         # create directory for nrn model
         self.createModelDir(sSim)
-        
+
         # write neurons into files
         self.writeNeurons(sSim)
 
@@ -52,15 +54,15 @@ class NRNModel():
 
         # write electrical couplings
         self.writeElecCoupling(sSim)
-        
-        # write main file for simulation 
+
+        # write main file for simulation
         self.writeMainSimFile(sSim)
 
     def writeElecCoupling(self, sSim):
         esList = sSim.network.elecSyns
         if len(esList) == 0:
             return
-        
+
         lj = self.lJust1
         neurons = sSim.network.neurons
         coupledNeurons = []
@@ -107,7 +109,7 @@ class NRNModel():
                 esf.write("// "+es.postSyn+" receives current I = "+str(g1)+"*("+es.postSyn+".v - "+es.preSyn+".v)\n")
                 esf.write(st1.ljust(2*lj) + " += "+str(g1)+"\t//(S/cm2)\n")
                 esf.write(st2.ljust(2*lj) + " += "+str(-1.0*g1)+"\t//(S/cm2)\n\n")
-                
+
                 # G2
                 st1 = "g.x["+es.preSyn+"_]["+es.preSyn+"_]"
                 st2 = "g.x["+es.preSyn+"_]["+es.postSyn+"_]"
@@ -126,10 +128,10 @@ class NRNModel():
         self.treatmentFile = "treatments.hoc"
         trtFileName = os.path.join(self.nrnDirPath,self.nrnDirName,self.treatmentFile)
 
-        print "TRTFilename: ", trtFileName
+        print("TRTFilename: ", trtFileName)
         with open(trtFileName, "w") as tf:
             tf.write("// create stim objects\n")
-            
+
             iClamps = sSim.treatemts.currentInjList
             nIC = len(iClamps)
             if nIC == 0:
@@ -151,12 +153,12 @@ class NRNModel():
                 tf.write(util.formatedObjectVar(stimID, "del") + "= "+ str(st).ljust(lj)+"// (ms)\n")
 
                 tf.write(util.formatedObjectVar(stimID, "dur") + "= "+ str(dur).ljust(lj) + "// (ms)\n")
-                # in SNNAP magnitude of current inject is in nA 
+                # in SNNAP magnitude of current inject is in nA
                 mag = float(ic.magnitude)
                 tf.write(util.formatedObjectVar(stimID, "amp") + "= "+ str(mag).ljust(lj) + "// (nA)\n\n")
 
         return
-        
+
     def writeChemSyns(self, sSim):
         lj = self.lJust1
         csList = sSim.network.chemSyns
@@ -175,7 +177,7 @@ class NRNModel():
                 XtType = cs.XtType
                 csf.write("// presyn: "+ cs.preSyn+ " postSyn: " + cs.postSyn+"\n")
                 csf.write("//cs_ fATType:"+ cs.fATType+ " ATType:" + AtType +" XtType:"+ XtType+"\n\n")
-                
+
                 csf.write("threshold".ljust(lj)+ "= "+neurons[cs.preSyn].treshold.ljust(lj)+ "// (mV)\n")
                 csf.write("delay".ljust(lj)+"= "+ "0.0".ljust(lj)+ "// (ms)\n")
                 csf.write("weight".ljust(lj)+ "= "+"1".ljust(lj)+ "\n\n")
@@ -193,15 +195,15 @@ class NRNModel():
                     elif XtType == '3':
                         csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At34_Xt3(0.5)\n\n")
                     else:
-                        print "WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!"
+                        print("WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!")
                 if AtType == '5':
                     if XtType == '1':
                         csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_1(0.5)\n\n")
                     elif XtType == '3':
-                        csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_3(0.5)\n\n") 
+                        csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_3(0.5)\n\n")
                     else:
-                        print "WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!"
-                    
+                        print("WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!")
+
                 csf.write(util.formatedObjectVar(csObjName, "e")+"= "+ cs.E.ljust(lj) + "// (mV)\n")
 
                 # in SNNAP synaptic conductance is in uS
@@ -216,7 +218,7 @@ class NRNModel():
                     csf.write(util.formatedObjectVar(csObjName, "fAt_a")+"= "+ cs.fAT_a + "\n")
                 if cs.fATType in ['3', '4', '5']:
                     csf.write(util.formatedObjectVar(csObjName, "fAt_b")+"= "+ cs.fAT_b + "\n")
-                    
+
                 csf.write(util.formatedObjectVar(csObjName, "Ics_type")+"= "+ cs.iCSType + "\n")
                 csf.write(util.formatedObjectVar(csObjName, "fAt_type")+"= "+ cs.fATType + "\n")
                 csf.write(util.formatedObjectVar(csObjName, "At_type")+"= "+ cs.ATType + "\n")
@@ -254,17 +256,17 @@ class NRNModel():
         rFileName = os.path.join(self.nrnDirPath,self.nrnDirName,rf_local)
 
         with open(rFileName, "w") as rf:
-            
+
             rf.write("This is an automatically generated directory.\n")
             rf.write("These scripts will allow you to recreate the results of "+self.simName+".smu in Neuron\n")
             rf.write("Before running them, conpile the .mod files found in SNNAP2NERON/utilityfiles/snnap_modfiles\n")
             rf.write("Then simply run file in this directory which is named sim_"+self.simName+".hoc in Neuron\n")
             rf.write("\n")
             rf.write("More info here: https://github.com/madawa87/SNNAP2NEURON/tree/master")
-            
+
         mainFileName = os.path.join(self.nrnDirPath,self.nrnDirName,"sim_"+self.simName+".hoc")
-        print "Main fileName: ", mainFileName
-        
+        print("Main fileName: ", mainFileName)
+
         with open(mainFileName, "w") as mf:
 
             mf.write("// load gui and standard run library\n")
@@ -319,28 +321,28 @@ class NRNModel():
             mf.write("alt_run()\n\n")
 
             mf.write("//load_file(\"fwrite.hoc\")\n\n")
-            print "\nSNNAP model was sucessfully converted to NEURON!"
-            
+            print("\nSNNAP model was sucessfully converted to NEURON!")
+
         return
 
     def createModelDir(self, sSim):
         """
         create a directrory called NRNModel_<SNNAP-simulation-name>
         """
-        
+
         self.nrnDirPath = sSim.simFilePath
         self.nrnDirName = "NRNModel_" + self.simName
 
         if not os.path.isdir(self.nrnDirPath + os.sep + self.nrnDirName):
             os.mkdir(self.nrnDirPath + os.sep + self.nrnDirName)
-            print "Neuron model is located in ", self.nrnDirPath+ os.sep + self.nrnDirName
-    
+            print("Neuron model is located in ", self.nrnDirPath+ os.sep + self.nrnDirName)
+
     def writeNeurons(self, sSim):
         """
         write neuron data into files
         """
         lj = self.lJust1
-        
+
 
         for nName in sSim.network.neurons.keys():
             nf_local = "create_"+nName+".hoc"
@@ -351,7 +353,7 @@ class NRNModel():
 
                 # append file name to the neuron filelist
                 self.neutonFiles.append(nf_local)
-                
+
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")
                 nf.write("\tnseg = 1\t\t// single compartment\n")
@@ -365,7 +367,7 @@ class NRNModel():
                     cm = float(nrn.cm)
                     nf.write("\tcm = "+ str(cm).ljust(lj)+"// (uF/cm2)\n")
                 else:
-                    print "WARNING: memAreas other than \"0\" are not supported yet!!!"
+                    print("WARNING: memAreas other than \"0\" are not supported yet!!!")
 
                 # insert leak current
                 vdgs = nrn.vdgs
@@ -382,7 +384,7 @@ class NRNModel():
                             if nrn.memAreaType == '0' or nrn.memAreaType == "":
                                 g = float(vdgs[vdgName].g) * 1.0e-6
                                 nf.write("\tg_pas = "+str(g).ljust(lj)+ "// (S/cm2)\n")
-                        
+
                 nf.write("}\n\n")
 
                 # write inital Vm
@@ -401,18 +403,18 @@ class NRNModel():
                         try:
                             g = float(vdgs[vdgName].g)
                         except:
-                            print "WARNING!: could not convert "+vdgName+ " conductance of neuron " + nName
-                            print "Exited unexpectedly!"
+                            print("WARNING!: could not convert "+vdgName+ " conductance of neuron " + nName)
+                            print("Exited unexpectedly!")
                             sys.exit(-1)
 
                     if not self.useNrnPas:
                         if ivdType == '5':
                             nf.write("// passive current\n")
-                        
+
                             vdgObjName = nName+"_"+vdgName
                             nf.write("objref "+vdgObjName+ "\n")
                             nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_pas_ivd5(0.5)\n")
-                        
+
                             nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                             nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n\n\n")
                             continue
@@ -424,7 +426,7 @@ class NRNModel():
                     if ivdType == '1' or ivdType == '3':
                         nf.write("//_A"+aType+"_B"+bType+"\n")
                         nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_tc_ivd"+ivdType+"_A"+aType+"(0.5)\n")
-                        
+
                         nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "p")+ "= "+vdgs[vdgName].P + "\n\n")
@@ -433,12 +435,12 @@ class NRNModel():
 
                         if ivdType == '1':
                             self.write_InActF_timeConstant(nf,  vdgObjName, vdgs[vdgName])
-                        
+
                     if ivdType == '2' or ivdType == '4':
                         nf.write("//_m"+mType+"_h"+hType+"\n")
-                        
+
                         nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_rc_ivd"+ivdType+"(0.5)\n")
-                        
+
                         nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "p")+ "= "+vdgs[vdgName].P + "\n\n")
@@ -464,7 +466,7 @@ class NRNModel():
         amType = ivd.amType
         file.write(util.formatedObjectVar(vdgObj, "am_type")+ "= "+ ivd.amType+ "\n")
         file.write(util.formatedObjectVar(vdgObj, "am_A")+ "= "+ ivd.am_A+ "\n")
-        
+
         if amType != '1':
             file.write(util.formatedObjectVar(vdgObj, "am_B")+ "= "+ (ivd.am_B).ljust(lj)+ "// (mV)\n")
 
@@ -474,21 +476,21 @@ class NRNModel():
                 if amType != '5' and amType != '6' and amType != '7':
 
                     file.write(util.formatedObjectVar(vdgObj, "am_D")+ "= "+ (ivd.am_D).ljust(lj)+ "// (mV)\n")
-            
+
         bmType = ivd.bmType
         file.write("\n")
         file.write(util.formatedObjectVar(vdgObj, "bm_type")+ "= "+ bmType+ "\n")
         file.write(util.formatedObjectVar(vdgObj, "bm_A")+ "= "+ ivd.bm_A+ "\n")
-        
+
         if bmType != '1':
             file.write(util.formatedObjectVar(vdgObj, "bm_B")+ "= "+ (ivd.bm_B).ljust(lj)+ "// (mV)\n")
 
             if bmType != '4' and bmType != '8' and bmType != '9':
                 file.write(util.formatedObjectVar(vdgObj, "bm_C")+ "= "+ (ivd.bm_C).ljust(lj)+ "// (mV)\n")
-                
+
                 if bmType != '5' and bmType != '6' and bmType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "bm_D")+ "= "+ (ivd.bm_D).ljust(lj)+ "// (mV)\n")
-                    
+
         file.write("\n")
 
     def write_InActF_rateConstant(self, file, vdgObj, ivd):
@@ -513,7 +515,7 @@ class NRNModel():
 
                 if ahType != '5' and ahType != '6' and ahType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "ah_D")+ "= "+ (ivd.ah_D).ljust(lj)+ "// (mV)\n")
-            
+
         bhType = ivd.bhType
         file.write("\n")
         file.write(util.formatedObjectVar(vdgObj, "bh_type")+ "= "+ bhType+ "\n")
@@ -521,10 +523,10 @@ class NRNModel():
 
         if bhType != '1':
             file.write(util.formatedObjectVar(vdgObj, "bh_B")+ "= "+ (ivd.bh_B).ljust(lj)+ "// (mV)\n")
- 
+
             if bhType != '4' and bhType != '8' and bhType != '9':
                 file.write(util.formatedObjectVar(vdgObj, "bh_C")+ "= "+ (ivd.bh_C).ljust(lj)+ "// (mV)\n")
- 
+
                 if bhType != '5' and bhType != '6' and bhType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "bh_D")+ "= "+ (ivd.bh_D).ljust(lj)+ "// (mV)\n")
 
@@ -535,14 +537,14 @@ class NRNModel():
         afType = ivd.AType
         if afType == "2":
             #file.write(util.formatedObjectVar(vdgObj, "A_IV")+ "= "+ ivd.A_IV+ "\n")
-            
+
             tAType = ivd.tAType
             file.write(util.formatedObjectVar(vdgObj, "tA_type")+ "= "+ tAType+ "\n")
 
             # convert seconds to ms
             tA_tx = float(ivd.tA_tx) * 1000.0
             file.write(util.formatedObjectVar(vdgObj, "tA_tx") + "= "+ str(tA_tx).ljust(lj)+ "// (ms)\n")
-            
+
             if tAType in ['2', '3', '6']:
                 file.write(util.formatedObjectVar(vdgObj, "tA_h1") + "= "+ (ivd.tA_h1).ljust(lj)+ "// (mV)\n")
                 file.write(util.formatedObjectVar(vdgObj, "tA_s1") + "= "+ (ivd.tA_s1).ljust(lj)+ "// (mV)\n")
@@ -557,12 +559,12 @@ class NRNModel():
                     if tAType != '6':
                         file.write(util.formatedObjectVar(vdgObj, "tA_p2") + "= "+ (ivd.tA_p2).ljust(lj)+ "\n\n")
             elif tAType != '1':
-                print "WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!"
+                print("WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!")
 
         # write steady state
         ssAType = ivd.ssAType
         file.write(util.formatedObjectVar(vdgObj, "ssA_type") + "= "+ ssAType+ "\n")
-        
+
         file.write(util.formatedObjectVar(vdgObj, "ssA_h") + "= "+ (ivd.ssA_h).ljust(lj)+ "// (mV)\n")
         file.write(util.formatedObjectVar(vdgObj, "ssA_s") + "= "+ (ivd.ssA_s).ljust(lj)+ "// (mV)\n")
         file.write(util.formatedObjectVar(vdgObj, "ssA_p") + "= "+ ivd.ssA_p+ "\n")
@@ -577,7 +579,7 @@ class NRNModel():
         inactfType = ivd.BType
         if inactfType == "2":
             #file.write(util.formatedObjectVar(vdgObj, "B_IV")+ "= "+ ivd.B_IV+ "\n")
-            
+
             tBType = ivd.tBType
             file.write(util.formatedObjectVar(vdgObj, "tB_type")+ "= "+ tBType+ "\n")
 
@@ -599,7 +601,7 @@ class NRNModel():
                     if tBType != '6':
                         file.write(util.formatedObjectVar(vdgObj, "tB_p2")+ "= "+ ivd.tB_p2+ "\n\n")
             elif tBType != '1':
-                print "WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!"
+                print("WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!")
 
         # write steady state
         ssBType = ivd.ssBType
@@ -617,153 +619,151 @@ class NRNModel():
         """
         print neuron data into stdout
         """
-        print "\n::: Neuron data :::"
+        print("\n::: Neuron data :::")
         for nName in sSim.network.neurons.keys():
-            print "Neuron Name: ", nName
+            print("Neuron Name: ", nName)
             nrn = sSim.network.neurons[nName]
-            print "treshold: ", nrn.treshold
-            print "spikeDur: ", nrn.spikeDur
-            print "vmInit: ", nrn.vmInit
-            print "cm: ", nrn.cm
-            print "memAreaType: ", nrn.memAreaType
+            print("treshold: ", nrn.treshold)
+            print("spikeDur: ", nrn.spikeDur)
+            print("vmInit: ", nrn.vmInit)
+            print("cm: ", nrn.cm)
+            print("memAreaType: ", nrn.memAreaType)
 
             for vdgName  in nrn.vdgs.keys():
                 vdg = nrn.vdgs[vdgName]
-                
-                print "---"+vdgName
+
+                print("---"+vdgName)
                 self.printIvd(vdg)
 
-            print ""
+            print("")
 
     def print_ActF_rateConstant(self, ivd):
         afType = ivd.mType
         if afType == "2" or afType == "3":
-            print "m_IV: ", ivd.m_IV            
+            print("m_IV: ", ivd.m_IV)
         if afType == "3":
-            print "m_L: ", ivd.m_L
+            print("m_L: ", ivd.m_L)
         amType = ivd.amType
-        print "amType: ", ivd.amType
-        print "am_A: ", ivd.am_A
+        print("amType: ", ivd.amType)
+        print("am_A: ", ivd.am_A)
         if amType != '1':
-            print "am_B: ", ivd.am_B
+            print("am_B: ", ivd.am_B)
         if amType != '4' and amType != '8' and amType != '9':
-            print "am_C: ", ivd.am_C
+            print("am_C: ", ivd.am_C)
         if amType != '5' and amType != '6' and amType != '7':
-            print "am_D: ", ivd.am_D
-            
+            print("am_D: ", ivd.am_D)
+
         bmType = ivd.bmType
-        print "bmType: ", ivd.bmType
-        print "bm_A: ", ivd.bm_A
+        print("bmType: ", ivd.bmType)
+        print("bm_A: ", ivd.bm_A)
         if bmType != '1':
-            print "bm_B: ", ivd.bm_B
+            print("bm_B: ", ivd.bm_B)
             if bmType != '4' and bmType != '8' and bmType != '9':
-                print "bm_C: ", ivd.bm_C
+                print("bm_C: ", ivd.bm_C)
                 if bmType != '5' and bmType != '6' and bmType != '7':
-                    print "bm_D: ", ivd.bm_D
+                    print("bm_D: ", ivd.bm_D)
 
     def print_InActF_rateConstant(self, ivd):
         inactfType = ivd.hType
         if inactfType == "2" or inactfType == "3":
-            print "h_IV: ", ivd.h_IV            
+            print("h_IV: ", ivd.h_IV)
         if inactfType == "3":
-            print "h_L: ", ivd.h_L
+            print("h_L: ", ivd.h_L)
         ahType = ivd.ahType
-        print "ahType: ", ahType
-        print "ah_A: ", ivd.ah_A
+        print("ahType: ", ahType)
+        print("ah_A: ", ivd.ah_A)
         if ahType != '1':
-            print "ah_B: ", ivd.ah_B
+            print("ah_B: ", ivd.ah_B)
         if ahType != '4' and ahType != '8' and ahType != '9':
-            print "ah_C: ", ivd.ah_C
+            print("ah_C: ", ivd.ah_C)
         if ahType != '5' and ahType != '6' and ahType != '7':
-            print "ah_D: ", ivd.ah_D
-            
+            print("ah_D: ", ivd.ah_D)
+
         bhType = ivd.bhType
-        print "bhType: ", ivd.bhType
-        print "bh_A: ", ivd.bh_A
+        print("bhType: ", ivd.bhType)
+        print("bh_A: ", ivd.bh_A)
         if bhType != '1':
-            print "bh_B: ", ivd.bh_B
+            print("bh_B: ", ivd.bh_B)
             if bhType != '4' and bhType != '8' and bhType != '9':
-                print "bh_C: ", ivd.bh_C
+                print("bh_C: ", ivd.bh_C)
                 if bhType != '5' and bhType != '6' and bhType != '7':
-                    print "bh_D: ", ivd.bh_D            
+                    print("bh_D: ", ivd.bh_D)
 
     def print_ActF_timeConstant(self, ivd):
         afType = ivd.AType
         if afType == "2":
-            print "A_IV: ", ivd.A_IV
-            
+            print("A_IV: ", ivd.A_IV)
+
             tAType = ivd.tAType
-            print "+++tAType: ", tAType
-            print "tA_tx: ", ivd.tA_tx
+            print("+++tAType: ", tAType)
+            print("tA_tx: ", ivd.tA_tx)
             if tAType == '2':
-                print "tA_tn: ", ivd.tA_tn
-                print "tA_h1: ", ivd.tA_h1
-                print "tA_s1: ", ivd.tA_s1
-                print "tA_p1: ", ivd.tA_p1
+                print("tA_tn: ", ivd.tA_tn)
+                print("tA_h1: ", ivd.tA_h1)
+                print("tA_s1: ", ivd.tA_s1)
+                print("tA_p1: ", ivd.tA_p1)
 
             elif tAType != '1':
-                print "WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!"
-            
+                print("WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!")
+
         ssAType = ivd.ssAType
-        print "ssAType: ", ssAType
-        
-        print "ssA_h: ", ivd.ssA_h
-        print "ssA_s: ", ivd.ssA_s
-        print "ssA_p: ", ivd.ssA_p            
+        print("ssAType: ", ssAType)
+
+        print("ssA_h: ", ivd.ssA_h)
+        print("ssA_s: ", ivd.ssA_s)
+        print("ssA_p: ", ivd.ssA_p)
         if ssAType == 2:
-            print "ssA_IV: ", ivd.ssA_An
+            print("ssA_IV: ", ivd.ssA_An)
 
     def print_InActF_timeConstant(self, ivd):
         inactfType = ivd.BType
         if inactfType == "2":
-            print "B_IV: ", ivd.B_IV
-            
+            print("B_IV: ", ivd.B_IV)
+
             tBType = ivd.tBType
-            print "+++tBType: ", tBType
-            print "tB_tx: ", ivd.tB_tx
+            print("+++tBType: ", tBType)
+            print("tB_tx: ", ivd.tB_tx)
             if tBType == '2':
-                print "tB_tn: ", ivd.tB_tn
-                print "tB_h1: ", ivd.tB_h1
-                print "tB_s1: ", ivd.tB_s1
-                print "tB_p1: ", ivd.tB_p1
+                print("tB_tn: ", ivd.tB_tn)
+                print("tB_h1: ", ivd.tB_h1)
+                print("tB_s1: ", ivd.tB_s1)
+                print("tB_p1: ", ivd.tB_p1)
 
             elif tBType != '1':
-                print "WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!"
-            
+                print("WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!")
+
         ssBType = ivd.ssBType
-        print "ssBType: ", ssBType
-        
-        print "ssB_h: ", ivd.ssB_h
-        print "ssB_s: ", ivd.ssB_s
-        print "ssB_p: ", ivd.ssB_p            
+        print("ssBType: ", ssBType)
+
+        print("ssB_h: ", ivd.ssB_h)
+        print("ssB_s: ", ivd.ssB_s)
+        print("ssB_p: ", ivd.ssB_p)
         if ssBType == 2:
-            print "ssB_IV: ", ivd.ssB_Bn
-            
+            print("ssB_IV: ", ivd.ssB_Bn)
+
     def printIvd(self, ivd):
         """
         """
         ivdType = ivd.ivdType
-        print "ivd type: ", ivdType
+        print("ivd type: ", ivdType)
         if ivdType == "1" or ivdType == "3":
-            print "------------------AType: ", ivd.AType
-            print "P: ", ivd.P
+            print("------------------AType: ", ivd.AType)
+            print("P: ", ivd.P)
             self.print_ActF_timeConstant(ivd)
 
         if ivdType == "2" or ivdType == "4":
-            print "mType: ", ivd.mType
-            print "P: ", ivd.P
+            print("mType: ", ivd.mType)
+            print("P: ", ivd.P)
             self.print_ActF_rateConstant(ivd)
 
         if ivdType == "1":
-            print "------------------BType: ", ivd.BType
+            print("------------------BType: ", ivd.BType)
             self.print_InActF_timeConstant(ivd)
 
         if ivdType == "2":
-            print "hType: ", ivd.hType
+            print("hType: ", ivd.hType)
             self.print_InActF_rateConstant(ivd)
 
 
-        print "E: ", ivd.E
-        print "g: ", ivd.g
-
-
+        print("E: ", ivd.E)
+        print("g: ", ivd.g)

--- a/nrnModelDist.py
+++ b/nrnModelDist.py
@@ -34,7 +34,7 @@ class NRNModelDist():
         self.useNrnPas = False
 
         self.neuronlist = {}
-        self.neutonFiles = []
+        self.neuronFiles = []
         self.chemSynFiles = []
         self.ElecCouplingFile = ""
         self.treatmentFile = None
@@ -264,7 +264,7 @@ class NRNModelDist():
             mf.write("load_file(\"nrngui.hoc\")\n\n")
 
             mf.write("// create neurons\n")
-            for nfile in self .neutonFiles:
+            for nfile in self .neuronFiles:
                 mf.write("load_file(\"" +nfile+ "\")\n")
             mf.write("\n")
 
@@ -343,7 +343,7 @@ class NRNModelDist():
 
             with open(nFileName, "w") as nf:
                 # append file name to the neuron filelist
-                self.neutonFiles.append(nf_local)
+                self.neuronFiles.append(nf_local)
 
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")
@@ -405,7 +405,7 @@ class NRNModelDist():
 
             with open(nFileName, "w") as nf:
                 # append file name to the neuron filelist
-                self.neutonFiles.append(nf_local)
+                self.neuronFiles.append(nf_local)
 
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")

--- a/nrnModelDist.py
+++ b/nrnModelDist.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import re
 import os
@@ -30,7 +32,7 @@ class NRNModelDist():
 
         # use neuron pas
         self.useNrnPas = False
-        
+
         self.neuronlist = {}
         self.neutonFiles = []
         self.chemSynFiles = []
@@ -39,11 +41,11 @@ class NRNModelDist():
 
         # create directory for nrn model
         self.createModelDir(sSim)
-        
+
         # write neurons into files
         #self.writeNeurons(sSim)
         self.writeNeuronsDist(sSim)
-        
+
         # write treatments
         self.writeTreatments(sSim)
 
@@ -55,8 +57,8 @@ class NRNModelDist():
 
         # write electrical couplings
         self.writeElecCoupling(sSim)
-        
-        # write main file for simulation 
+
+        # write main file for simulation
         self.writeMainSimFile(sSim)
 
         # write plotting file
@@ -66,7 +68,7 @@ class NRNModelDist():
         esList = sSim.network.elecSyns
         if len(esList) == 0:
             return
-        
+
         lj = self.lJust1
 
         neurons = sSim.network.neurons
@@ -113,7 +115,7 @@ class NRNModelDist():
                 esf.write("// "+es.postSyn+" receives current I = "+str(g1)+"*("+es.postSyn+".v - "+es.preSyn+".v)\n")
                 esf.write(st1.ljust(2*lj) + " += "+str(g1)+"\t//(S/cm2)\n")
                 esf.write(st2.ljust(2*lj) + " += "+str(-1.0*g1)+"\t//(S/cm2)\n\n")
-                
+
                 # G2
                 st1 = "g.x["+es.preSyn+"_]["+es.preSyn+"_]"
                 st2 = "g.x["+es.preSyn+"_]["+es.postSyn+"_]"
@@ -124,7 +126,7 @@ class NRNModelDist():
             esf.write("\n// create the electrical synapses\n")
             esf.write("es = new LinearMechanism(c, g, y, b, sl, xvec)\n")
         return
-    
+
     def writeTreatments(self, sSim):
         lj = self.lJust1
         trtList = sSim.network.chemSyns
@@ -132,10 +134,10 @@ class NRNModelDist():
         self.treatmentFile = "treatments.hoc"
         trtFileName = os.path.join(self.nrnDirPath,self.nrnDirName,self.treatmentFile)
 
-        print "TRTFilename: ", trtFileName
+        print("TRTFilename: ", trtFileName)
         with open(trtFileName, "w") as tf:
             tf.write("// create stim objects\n")
-            
+
             iClamps = sSim.treatemts.currentInjList
             nIC = len(iClamps)
             if nIC == 0:
@@ -157,7 +159,7 @@ class NRNModelDist():
                 tf.write(util.formatedObjectVar(stimID, "del") + "= "+ str(st).ljust(lj)+"// (ms)\n")
 
                 tf.write(util.formatedObjectVar(stimID, "dur") + "= "+ str(dur).ljust(lj) + "// (ms)\n")
-                # in SNNAP magnitude of current inject is in nA 
+                # in SNNAP magnitude of current inject is in nA
                 mag = float(ic.magnitude)
                 tf.write(util.formatedObjectVar(stimID, "amp") + "= "+ str(mag).ljust(lj) + "// (nA)\n\n")
 
@@ -180,7 +182,7 @@ class NRNModelDist():
                 XtType = cs.XtType
                 csf.write("// presyn: "+ cs.preSyn+ " postSyn: " + cs.postSyn+"\n")
                 csf.write("//cs_ fATType:"+ cs.fATType+ " ATType:" + AtType +" XtType:"+ XtType+"\n\n")
-                
+
                 csf.write("threshold".ljust(lj)+ "= "+neurons[cs.preSyn].treshold.ljust(lj)+ "// (mV)\n")
                 csf.write("delay".ljust(lj)+"= "+ "0.0".ljust(lj)+ "// (ms)\n")
                 csf.write("weight".ljust(lj)+ "= "+"1".ljust(lj)+ "\n\n")
@@ -198,15 +200,15 @@ class NRNModelDist():
                     elif XtType == '3':
                         csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At34_Xt3(0.5)\n\n")
                     else:
-                        print "WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!"
+                        print("WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!")
                 if AtType == '5':
                     if XtType == '1':
                         csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_1(0.5)\n\n")
                     elif XtType == '3':
-                        csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_3(0.5)\n\n") 
+                        csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_3(0.5)\n\n")
                     else:
-                        print "WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!"
-                    
+                        print("WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!")
+
                 csf.write(util.formatedObjectVar(csObjName, "e")+"= "+ cs.E.ljust(lj) + "// (mV)\n")
 
                 # in SNNAP synaptic conductance is in uS
@@ -221,7 +223,7 @@ class NRNModelDist():
                     csf.write(util.formatedObjectVar(csObjName, "fAt_a")+"= "+ cs.fAT_a + "\n")
                 if cs.fATType in ['3', '4', '5']:
                     csf.write(util.formatedObjectVar(csObjName, "fAt_b")+"= "+ cs.fAT_b + "\n")
-                    
+
                 csf.write(util.formatedObjectVar(csObjName, "Ics_type")+"= "+ cs.iCSType + "\n")
                 csf.write(util.formatedObjectVar(csObjName, "fAt_type")+"= "+ cs.fATType + "\n")
                 csf.write(util.formatedObjectVar(csObjName, "At_type")+"= "+ cs.ATType + "\n")
@@ -251,12 +253,12 @@ class NRNModelDist():
                 csf.write(cs.preSyn+" "+ csncObjName +" = new NetCon(&v(0.5), "+ csObjName+ ", threshold, delay, weight)\n\n")
             i = i+1
         return
-    
+
     def writeMainSimFile(self, sSim):
         lj = self.lJust1
         mainFileName = os.path.join(self.nrnDirPath,self.nrnDirName,"sim_"+self.simName+".hoc")
-        print "Main fileName: ", mainFileName
-        
+        print("Main fileName: ", mainFileName)
+
         with open(mainFileName, "w") as mf:
             mf.write("// load gui and standard run library\n")
             mf.write("load_file(\"nrngui.hoc\")\n\n")
@@ -310,39 +312,39 @@ class NRNModelDist():
             mf.write("alt_run()\n\n")
 
             mf.write("//load_file(\"fwrite.hoc\")\n\n")
-            print "\nSNNAP model was sucessfully converted to NEURON!"
-            
+            print("\nSNNAP model was sucessfully converted to NEURON!")
+
         return
 
     def createModelDir(self, sSim):
         """
         create a directrory called NRNModel_<SNNAP-simulation-name>
-        """        
+        """
         self.nrnDirPath = sSim.simFilePath
         self.nrnDirName = "NRNModel_" + self.simName
 
         if not os.path.isdir(self.nrnDirPath + os.sep + self.nrnDirName):
             os.mkdir(self.nrnDirPath + os.sep + self.nrnDirName)
-            print "Neuron model is located in ", self.nrnDirPath + os.sep + self.nrnDirName
-    
+            print("Neuron model is located in ", self.nrnDirPath + os.sep + self.nrnDirName)
+
     def writeNeuronsDist(self, sSim):
         """
         write neuron data into files
         """
         lj = self.lJust1
-        
+
         for nName in sSim.network.neurons.keys():
             nf_local = "create_"+nName+".hoc"
             nFileName = os.path.join(self.nrnDirPath,self.nrnDirName,nf_local)
             nrn = sSim.network.neurons[nName]
 
-            # name given to distributed mechanics of this neuron 
+            # name given to distributed mechanics of this neuron
             nrnModName = nName+"_mechs"
 
             with open(nFileName, "w") as nf:
                 # append file name to the neuron filelist
                 self.neutonFiles.append(nf_local)
-                
+
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")
                 nf.write("\tnseg = 1\t\t// single compartment\n")
@@ -356,11 +358,11 @@ class NRNModelDist():
                     cm = float(nrn.cm)
                     nf.write("\tcm = "+ str(cm).ljust(lj)+"// (uF/cm2)\n")
                 else:
-                    print "WARNING: memAreas other than \"0\" are not supported yet!!!"
+                    print("WARNING: memAreas other than \"0\" are not supported yet!!!")
 
                 # insert leak current
                 vdgs = nrn.vdgs
-                
+
                 nf.write("\tinsert "+ nrnModName +"\n")
 
                 # if using pas mechanic for passive(leak) current
@@ -376,7 +378,7 @@ class NRNModelDist():
                             if nrn.memAreaType == '0' or nrn.memAreaType == "":
                                 g = float(vdgs[vdgName].g) * 1.0e-6
                                 nf.write("\tg_pas = "+str(g).ljust(lj)+ "// (S/cm2)\n")
-                        
+
                 nf.write("}\n\n")
 
                 # write inital Vm
@@ -404,7 +406,7 @@ class NRNModelDist():
             with open(nFileName, "w") as nf:
                 # append file name to the neuron filelist
                 self.neutonFiles.append(nf_local)
-                
+
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")
                 nf.write("\tnseg = 1\t\t// single compartment\n")
@@ -418,7 +420,7 @@ class NRNModelDist():
                     cm = float(nrn.cm)
                     nf.write("\tcm = "+ str(cm).ljust(lj)+"// (uF/cm2)\n")
                 else:
-                    print "WARNING: memAreas other than \"0\" are not supported yet!!!"
+                    print("WARNING: memAreas other than \"0\" are not supported yet!!!")
 
                 # insert leak current
                 vdgs = nrn.vdgs
@@ -435,7 +437,7 @@ class NRNModelDist():
                             if nrn.memAreaType == '0' or nrn.memAreaType == "":
                                 g = float(vdgs[vdgName].g) * 1.0e-6
                                 nf.write("\tg_pas = "+str(g).ljust(lj)+ "// (S/cm2)\n")
-                        
+
                 nf.write("}\n\n")
 
                 # write inital Vm
@@ -454,18 +456,18 @@ class NRNModelDist():
                         try:
                             g = float(vdgs[vdgName].g)
                         except:
-                            print "WARNING!: could not convert "+vdgName+ " conductance of neuron " + nName
-                            print "Exited unexpectedly!"
+                            print("WARNING!: could not convert "+vdgName+ " conductance of neuron " + nName)
+                            print("Exited unexpectedly!")
                             sys.exit(-1)
 
                     if not self.useNrnPas:
                         if ivdType == '5':
                             nf.write("// passive current\n")
-                        
+
                             vdgObjName = nName+"_"+vdgName
                             nf.write("objref "+vdgObjName+ "\n")
                             nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_pas_ivd5(0.5)\n")
-                        
+
                             nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                             nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n\n\n")
                             continue
@@ -477,7 +479,7 @@ class NRNModelDist():
                     if ivdType == '1' or ivdType == '3':
                         nf.write("//_A"+aType+"_B"+bType+"\n")
                         nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_tc_ivd"+ivdType+"_A"+aType+"(0.5)\n")
-                        
+
                         nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "p")+ "= "+vdgs[vdgName].P + "\n\n")
@@ -486,12 +488,12 @@ class NRNModelDist():
 
                         if ivdType == '1':
                             self.write_InActF_timeConstant(nf,  vdgObjName, vdgs[vdgName])
-                        
+
                     if ivdType == '2' or ivdType == '4':
                         nf.write("//_m"+mType+"_h"+hType+"\n")
-                        
+
                         nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_rc_ivd"+ivdType+"(0.5)\n")
-                        
+
                         nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "p")+ "= "+vdgs[vdgName].P + "\n\n")
@@ -517,7 +519,7 @@ class NRNModelDist():
         amType = ivd.amType
         file.write(util.formatedObjectVar(vdgObj, "am_type")+ "= "+ ivd.amType+ "\n")
         file.write(util.formatedObjectVar(vdgObj, "am_A")+ "= "+ ivd.am_A+ "\n")
-        
+
         if amType != '1':
             file.write(util.formatedObjectVar(vdgObj, "am_B")+ "= "+ (ivd.am_B).ljust(lj)+ "// (mV)\n")
 
@@ -527,21 +529,21 @@ class NRNModelDist():
                 if amType != '5' and amType != '6' and amType != '7':
 
                     file.write(util.formatedObjectVar(vdgObj, "am_D")+ "= "+ (ivd.am_D).ljust(lj)+ "// (mV)\n")
-            
+
         bmType = ivd.bmType
         file.write("\n")
         file.write(util.formatedObjectVar(vdgObj, "bm_type")+ "= "+ bmType+ "\n")
         file.write(util.formatedObjectVar(vdgObj, "bm_A")+ "= "+ ivd.bm_A+ "\n")
-        
+
         if bmType != '1':
             file.write(util.formatedObjectVar(vdgObj, "bm_B")+ "= "+ (ivd.bm_B).ljust(lj)+ "// (mV)\n")
 
             if bmType != '4' and bmType != '8' and bmType != '9':
                 file.write(util.formatedObjectVar(vdgObj, "bm_C")+ "= "+ (ivd.bm_C).ljust(lj)+ "// (mV)\n")
-                
+
                 if bmType != '5' and bmType != '6' and bmType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "bm_D")+ "= "+ (ivd.bm_D).ljust(lj)+ "// (mV)\n")
-                    
+
         file.write("\n")
 
     def write_InActF_rateConstant(self, file, vdgObj, ivd):
@@ -566,7 +568,7 @@ class NRNModelDist():
 
                 if ahType != '5' and ahType != '6' and ahType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "ah_D")+ "= "+ (ivd.ah_D).ljust(lj)+ "// (mV)\n")
-            
+
         bhType = ivd.bhType
         file.write("\n")
         file.write(util.formatedObjectVar(vdgObj, "bh_type")+ "= "+ bhType+ "\n")
@@ -574,10 +576,10 @@ class NRNModelDist():
 
         if bhType != '1':
             file.write(util.formatedObjectVar(vdgObj, "bh_B")+ "= "+ (ivd.bh_B).ljust(lj)+ "// (mV)\n")
- 
+
             if bhType != '4' and bhType != '8' and bhType != '9':
                 file.write(util.formatedObjectVar(vdgObj, "bh_C")+ "= "+ (ivd.bh_C).ljust(lj)+ "// (mV)\n")
- 
+
                 if bhType != '5' and bhType != '6' and bhType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "bh_D")+ "= "+ (ivd.bh_D).ljust(lj)+ "// (mV)\n")
 
@@ -588,14 +590,14 @@ class NRNModelDist():
         afType = ivd.AType
         if afType == "2":
             #file.write(util.formatedObjectVar(vdgObj, "A_IV")+ "= "+ ivd.A_IV+ "\n")
-            
+
             tAType = ivd.tAType
             file.write(util.formatedObjectVar(vdgObj, "tA_type")+ "= "+ tAType+ "\n")
 
             # convert seconds to ms
             tA_tx = float(ivd.tA_tx) * 1000.0
             file.write(util.formatedObjectVar(vdgObj, "tA_tx") + "= "+ str(tA_tx).ljust(lj)+ "// (ms)\n")
-            
+
             if tAType in ['2', '3', '6']:
                 file.write(util.formatedObjectVar(vdgObj, "tA_h1") + "= "+ (ivd.tA_h1).ljust(lj)+ "// (mV)\n")
                 file.write(util.formatedObjectVar(vdgObj, "tA_s1") + "= "+ (ivd.tA_s1).ljust(lj)+ "// (mV)\n")
@@ -610,12 +612,12 @@ class NRNModelDist():
                     if tAType != '6':
                         file.write(util.formatedObjectVar(vdgObj, "tA_p2") + "= "+ (ivd.tA_p2).ljust(lj)+ "\n\n")
             elif tAType != '1':
-                print "WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!"
+                print("WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!")
 
         # write steady state
         ssAType = ivd.ssAType
         file.write(util.formatedObjectVar(vdgObj, "ssA_type") + "= "+ ssAType+ "\n")
-        
+
         file.write(util.formatedObjectVar(vdgObj, "ssA_h") + "= "+ (ivd.ssA_h).ljust(lj)+ "// (mV)\n")
         file.write(util.formatedObjectVar(vdgObj, "ssA_s") + "= "+ (ivd.ssA_s).ljust(lj)+ "// (mV)\n")
         file.write(util.formatedObjectVar(vdgObj, "ssA_p") + "= "+ ivd.ssA_p+ "\n")
@@ -630,7 +632,7 @@ class NRNModelDist():
         inactfType = ivd.BType
         if inactfType == "2":
             #file.write(util.formatedObjectVar(vdgObj, "B_IV")+ "= "+ ivd.B_IV+ "\n")
-            
+
             tBType = ivd.tBType
             file.write(util.formatedObjectVar(vdgObj, "tB_type")+ "= "+ tBType+ "\n")
 
@@ -652,7 +654,7 @@ class NRNModelDist():
                     if tBType != '6':
                         file.write(util.formatedObjectVar(vdgObj, "tB_p2")+ "= "+ ivd.tB_p2+ "\n\n")
             elif tBType != '1':
-                print "WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!"
+                print("WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!")
 
         # write steady state
         ssBType = ivd.ssBType
@@ -669,150 +671,148 @@ class NRNModelDist():
         """
         print neuron data into stdout
         """
-        print "\n::: Neuron data :::"
+        print("\n::: Neuron data :::")
         for nName in sSim.network.neurons.keys():
-            print "Neuron Name: ", nName
+            print("Neuron Name: ", nName)
             nrn = sSim.network.neurons[nName]
-            print "treshold: ", nrn.treshold
-            print "spikeDur: ", nrn.spikeDur
-            print "vmInit: ", nrn.vmInit
-            print "cm: ", nrn.cm
-            print "memAreaType: ", nrn.memAreaType
+            print("treshold: ", nrn.treshold)
+            print("spikeDur: ", nrn.spikeDur)
+            print("vmInit: ", nrn.vmInit)
+            print("cm: ", nrn.cm)
+            print("memAreaType: ", nrn.memAreaType)
 
             for vdgName  in nrn.vdgs.keys():
                 vdg = nrn.vdgs[vdgName]
-                
-                print "---"+vdgName
+
+                print("---"+vdgName)
                 self.printIvd(vdg)
 
-            print ""
+            print("")
 
     def print_ActF_rateConstant(self, ivd):
         afType = ivd.mType
         if afType == "2" or afType == "3":
-            print "m_IV: ", ivd.m_IV            
+            print("m_IV: ", ivd.m_IV)
         if afType == "3":
-            print "m_L: ", ivd.m_L
+            print("m_L: ", ivd.m_L)
         amType = ivd.amType
-        print "amType: ", ivd.amType
-        print "am_A: ", ivd.am_A
+        print("amType: ", ivd.amType)
+        print("am_A: ", ivd.am_A)
         if amType != '1':
-            print "am_B: ", ivd.am_B
+            print("am_B: ", ivd.am_B)
         if amType != '4' and amType != '8' and amType != '9':
-            print "am_C: ", ivd.am_C
+            print("am_C: ", ivd.am_C)
         if amType != '5' and amType != '6' and amType != '7':
-            print "am_D: ", ivd.am_D
-            
+            print("am_D: ", ivd.am_D)
+
         bmType = ivd.bmType
-        print "bmType: ", ivd.bmType
-        print "bm_A: ", ivd.bm_A
+        print("bmType: ", ivd.bmType)
+        print("bm_A: ", ivd.bm_A)
         if bmType != '1':
-            print "bm_B: ", ivd.bm_B
+            print("bm_B: ", ivd.bm_B)
             if bmType != '4' and bmType != '8' and bmType != '9':
-                print "bm_C: ", ivd.bm_C
+                print("bm_C: ", ivd.bm_C)
                 if bmType != '5' and bmType != '6' and bmType != '7':
-                    print "bm_D: ", ivd.bm_D
+                    print("bm_D: ", ivd.bm_D)
 
     def print_InActF_rateConstant(self, ivd):
         inactfType = ivd.hType
         if inactfType == "2" or inactfType == "3":
-            print "h_IV: ", ivd.h_IV            
+            print("h_IV: ", ivd.h_IV)
         if inactfType == "3":
-            print "h_L: ", ivd.h_L
+            print("h_L: ", ivd.h_L)
         ahType = ivd.ahType
-        print "ahType: ", ahType
-        print "ah_A: ", ivd.ah_A
+        print("ahType: ", ahType)
+        print("ah_A: ", ivd.ah_A)
         if ahType != '1':
-            print "ah_B: ", ivd.ah_B
+            print("ah_B: ", ivd.ah_B)
         if ahType != '4' and ahType != '8' and ahType != '9':
-            print "ah_C: ", ivd.ah_C
+            print("ah_C: ", ivd.ah_C)
         if ahType != '5' and ahType != '6' and ahType != '7':
-            print "ah_D: ", ivd.ah_D
-            
+            print("ah_D: ", ivd.ah_D)
+
         bhType = ivd.bhType
-        print "bhType: ", ivd.bhType
-        print "bh_A: ", ivd.bh_A
+        print("bhType: ", ivd.bhType)
+        print("bh_A: ", ivd.bh_A)
         if bhType != '1':
-            print "bh_B: ", ivd.bh_B
+            print("bh_B: ", ivd.bh_B)
             if bhType != '4' and bhType != '8' and bhType != '9':
-                print "bh_C: ", ivd.bh_C
+                print("bh_C: ", ivd.bh_C)
                 if bhType != '5' and bhType != '6' and bhType != '7':
-                    print "bh_D: ", ivd.bh_D            
+                    print("bh_D: ", ivd.bh_D)
 
     def print_ActF_timeConstant(self, ivd):
         afType = ivd.AType
         if afType == "2":
-            print "A_IV: ", ivd.A_IV
-            
+            print("A_IV: ", ivd.A_IV)
+
             tAType = ivd.tAType
-            print "+++tAType: ", tAType
-            print "tA_tx: ", ivd.tA_tx
+            print("+++tAType: ", tAType)
+            print("tA_tx: ", ivd.tA_tx)
             if tAType == '2':
-                print "tA_tn: ", ivd.tA_tn
-                print "tA_h1: ", ivd.tA_h1
-                print "tA_s1: ", ivd.tA_s1
-                print "tA_p1: ", ivd.tA_p1
+                print("tA_tn: ", ivd.tA_tn)
+                print("tA_h1: ", ivd.tA_h1)
+                print("tA_s1: ", ivd.tA_s1)
+                print("tA_p1: ", ivd.tA_p1)
 
             elif tAType != '1':
-                print "WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!"
-            
+                print("WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!")
+
         ssAType = ivd.ssAType
-        print "ssAType: ", ssAType
-        
-        print "ssA_h: ", ivd.ssA_h
-        print "ssA_s: ", ivd.ssA_s
-        print "ssA_p: ", ivd.ssA_p            
+        print("ssAType: ", ssAType)
+
+        print("ssA_h: ", ivd.ssA_h)
+        print("ssA_s: ", ivd.ssA_s)
+        print("ssA_p: ", ivd.ssA_p)
         if ssAType == 2:
-            print "ssA_IV: ", ivd.ssA_An
+            print("ssA_IV: ", ivd.ssA_An)
 
     def print_InActF_timeConstant(self, ivd):
         inactfType = ivd.BType
         if inactfType == "2":
-            print "B_IV: ", ivd.B_IV
-            
+            print("B_IV: ", ivd.B_IV)
+
             tBType = ivd.tBType
-            print "+++tBType: ", tBType
-            print "tB_tx: ", ivd.tB_tx
+            print("+++tBType: ", tBType)
+            print("tB_tx: ", ivd.tB_tx)
             if tBType == '2':
-                print "tB_tn: ", ivd.tB_tn
-                print "tB_h1: ", ivd.tB_h1
-                print "tB_s1: ", ivd.tB_s1
-                print "tB_p1: ", ivd.tB_p1
+                print("tB_tn: ", ivd.tB_tn)
+                print("tB_h1: ", ivd.tB_h1)
+                print("tB_s1: ", ivd.tB_s1)
+                print("tB_p1: ", ivd.tB_p1)
 
             elif tBType != '1':
-                print "WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!"
-            
+                print("WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!")
+
         ssBType = ivd.ssBType
-        print "ssBType: ", ssBType
-        
-        print "ssB_h: ", ivd.ssB_h
-        print "ssB_s: ", ivd.ssB_s
-        print "ssB_p: ", ivd.ssB_p            
+        print("ssBType: ", ssBType)
+
+        print("ssB_h: ", ivd.ssB_h)
+        print("ssB_s: ", ivd.ssB_s)
+        print("ssB_p: ", ivd.ssB_p)
         if ssBType == 2:
-            print "ssB_IV: ", ivd.ssB_Bn
-            
+            print("ssB_IV: ", ivd.ssB_Bn)
+
     def printIvd(self, ivd):
         ivdType = ivd.ivdType
-        print "ivd type: ", ivdType
+        print("ivd type: ", ivdType)
         if ivdType == "1" or ivdType == "3":
-            print "------------------AType: ", ivd.AType
-            print "P: ", ivd.P
+            print("------------------AType: ", ivd.AType)
+            print("P: ", ivd.P)
             self.print_ActF_timeConstant(ivd)
 
         if ivdType == "2" or ivdType == "4":
-            print "mType: ", ivd.mType
-            print "P: ", ivd.P
+            print("mType: ", ivd.mType)
+            print("P: ", ivd.P)
             self.print_ActF_rateConstant(ivd)
 
         if ivdType == "1":
-            print "------------------BType: ", ivd.BType
+            print("------------------BType: ", ivd.BType)
             self.print_InActF_timeConstant(ivd)
 
         if ivdType == "2":
-            print "hType: ", ivd.hType
+            print("hType: ", ivd.hType)
             self.print_InActF_rateConstant(ivd)
 
-        print "E: ", ivd.E
-        print "g: ", ivd.g
-
-
+        print("E: ", ivd.E)
+        print("g: ", ivd.g)

--- a/nrnModelDist.py
+++ b/nrnModelDist.py
@@ -325,7 +325,7 @@ class NRNModelDist():
 
         if not os.path.isdir(self.nrnDirPath + os.sep + self.nrnDirName):
             os.mkdir(self.nrnDirPath + os.sep + self.nrnDirName)
-            print("Neuron model is located in ", self.nrnDirPath + os.sep + self.nrnDirName)
+            print("NEURON model is located in ", self.nrnDirPath + os.sep + self.nrnDirName)
 
     def writeNeuronsDist(self, sSim):
         """
@@ -505,7 +505,7 @@ class NRNModelDist():
                     nf.write("\n")
 
     def write_ActF_rateConstant(self, file, vdgObj, ivd):
-        # in SNNAP time derivatives are also in seconds. to convert them to Neuron time derivatives
+        # in SNNAP time derivatives are also in seconds. to convert them to NEURON time derivatives
         # must be divided by 1000.0
         lj = self.lJust1
         afType = ivd.mType

--- a/nrnModelPoint.py
+++ b/nrnModelPoint.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import re
 import os
@@ -32,7 +34,7 @@ class NRNModelPoint():
 
         # use neuron pas
         self.useNrnPas = False
-        
+
         self.neuronlist = {}
         self.neutonFiles = []
         self.chemSynFiles = []
@@ -41,7 +43,7 @@ class NRNModelPoint():
 
         # create directory for nrn model
         self.createModelDir(sSim)
-        
+
         # write neurons into files
         self.writeNeurons(sSim)
 
@@ -56,8 +58,8 @@ class NRNModelPoint():
 
         # write electrical couplings
         self.writeElecCoupling(sSim)
-        
-        # write main file for simulation 
+
+        # write main file for simulation
         self.writeMainSimFile(sSim)
 
         # write plotting file
@@ -67,7 +69,7 @@ class NRNModelPoint():
         esList = sSim.network.elecSyns
         if len(esList) == 0:
             return
-        
+
         lj = self.lJust1
 
         neurons = sSim.network.neurons
@@ -114,7 +116,7 @@ class NRNModelPoint():
                 esf.write("// "+es.postSyn+" receives current I = "+str(g1)+"*("+es.postSyn+".v - "+es.preSyn+".v)\n")
                 esf.write(st1.ljust(2*lj) + " += "+str(g1)+"\t//(S/cm2)\n")
                 esf.write(st2.ljust(2*lj) + " += "+str(-1.0*g1)+"\t//(S/cm2)\n\n")
-                
+
                 # G2
                 st1 = "g.x["+es.preSyn+"_]["+es.preSyn+"_]"
                 st2 = "g.x["+es.preSyn+"_]["+es.postSyn+"_]"
@@ -133,10 +135,10 @@ class NRNModelPoint():
         self.treatmentFile = "treatments.hoc"
         trtFileName = os.path.join(self.nrnDirPath,self.nrnDirName,self.treatmentFile)
 
-        print "TRTFilename: ", trtFileName
+        print("TRTFilename: ", trtFileName)
         with open(trtFileName, "w") as tf:
             tf.write("// create stim objects\n")
-            
+
             iClamps = sSim.treatemts.currentInjList
             nIC = len(iClamps)
             if nIC == 0:
@@ -158,7 +160,7 @@ class NRNModelPoint():
                 tf.write(util.formatedObjectVar(stimID, "del") + "= "+ str(st).ljust(lj)+"// (ms)\n")
 
                 tf.write(util.formatedObjectVar(stimID, "dur") + "= "+ str(dur).ljust(lj) + "// (ms)\n")
-                # in SNNAP magnitude of current inject is in nA 
+                # in SNNAP magnitude of current inject is in nA
                 mag = float(ic.magnitude)
                 tf.write(util.formatedObjectVar(stimID, "amp") + "= "+ str(mag).ljust(lj) + "// (nA)\n\n")
 
@@ -181,7 +183,7 @@ class NRNModelPoint():
                 XtType = cs.XtType
                 csf.write("// presyn: "+ cs.preSyn+ " postSyn: " + cs.postSyn+"\n")
                 csf.write("//cs_ fATType:"+ cs.fATType+ " ATType:" + AtType +" XtType:"+ XtType+"\n\n")
-                
+
                 csf.write("threshold".ljust(lj)+ "= "+neurons[cs.preSyn].treshold.ljust(lj)+ "// (mV)\n")
                 csf.write("delay".ljust(lj)+"= "+ "0.0".ljust(lj)+ "// (ms)\n")
                 csf.write("weight".ljust(lj)+ "= "+"1".ljust(lj)+ "\n\n")
@@ -199,15 +201,15 @@ class NRNModelPoint():
                     elif XtType == '3':
                         csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At34_Xt3(0.5)\n\n")
                     else:
-                        print "WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!"
+                        print("WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!")
                 if AtType == '5':
                     if XtType == '1':
                         csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_1(0.5)\n\n")
                     elif XtType == '3':
-                        csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_3(0.5)\n\n") 
+                        csf.write(cs.postSyn+" "+ csObjName +" = new snnap_cs2_At5_Xt_3(0.5)\n\n")
                     else:
-                        print "WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!"
-                    
+                        print("WARNING: Xt types other than \"1\" or \"3\" are not supported yet!!!")
+
                 csf.write(util.formatedObjectVar(csObjName, "e")+"= "+ cs.E.ljust(lj) + "// (mV)\n")
 
                 # in SNNAP synaptic conductance is in uS
@@ -223,7 +225,7 @@ class NRNModelPoint():
                     csf.write(util.formatedObjectVar(csObjName, "fAt_a")+"= "+ cs.fAT_a + "\n")
                 if cs.fATType in ['3', '4', '5']:
                     csf.write(util.formatedObjectVar(csObjName, "fAt_b")+"= "+ cs.fAT_b + "\n")
-                    
+
                 csf.write(util.formatedObjectVar(csObjName, "Ics_type")+"= "+ cs.iCSType + "\n")
                 csf.write(util.formatedObjectVar(csObjName, "fAt_type")+"= "+ cs.fATType + "\n")
                 csf.write(util.formatedObjectVar(csObjName, "At_type")+"= "+ cs.ATType + "\n")
@@ -253,7 +255,7 @@ class NRNModelPoint():
                 csf.write(cs.preSyn+" "+ csncObjName +" = new NetCon(&v(0.5), "+ csObjName+ ", threshold, delay, weight)\n\n")
             i = i+1
         return
-    
+
     def writeMainSimFile(self, sSim):
         lj = self.lJust1
 
@@ -268,11 +270,11 @@ class NRNModelPoint():
             rf.write("\n")
             rf.write("More info here: https://github.com/madawa87/SNNAP2NEURON/tree/master")
 
-        print "readme.txt"
-        
+        print("readme.txt")
+
         mainFileName = os.path.join(self.nrnDirPath,self.nrnDirName,"sim_"+self.simName+".hoc")
-        print "Main fileName: ", mainFileName
-        
+        print("Main fileName: ", mainFileName)
+
         with open(mainFileName, "w") as mf:
             mf.write("// load gui and standard run library\n")
             mf.write("load_file(\"nrngui.hoc\")\n\n")
@@ -326,26 +328,26 @@ class NRNModelPoint():
             mf.write("alt_run()\n\n")
 
             mf.write("//load_file(\"fwrite.hoc\")\n\n")
-            print "\nSNNAP model was sucessfully converted to NEURON!"            
+            print("\nSNNAP model was sucessfully converted to NEURON!")
         return
 
     def createModelDir(self, sSim):
         """
         create a directrory called NRNModel_<SNNAP-simulation-name>
         """
-        
+
         self.nrnDirPath = sSim.simFilePath
         self.nrnDirName = "NRNModel_" + self.simName
 
         if not os.path.isdir(self.nrnDirPath + os.sep + self.nrnDirName):
             os.mkdir(self.nrnDirPath + os.sep + self.nrnDirName)
-            print "Neuron model is located in ", self.nrnDirPath + os.sep + self.nrnDirName
-    
+            print("Neuron model is located in ", self.nrnDirPath + os.sep + self.nrnDirName)
+
     def writeNeurons(self, sSim):
         """
         write neuron data into files
         """
-        
+
         lj = self.lJust1
         for nName in sSim.network.neurons.keys():
             nf_local = "create_"+nName+".hoc"
@@ -355,7 +357,7 @@ class NRNModelPoint():
             with open(nFileName, "w") as nf:
                 # append file name to the neuron filelist
                 self.neutonFiles.append(nf_local)
-                
+
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")
                 nf.write("\tnseg = 1\t\t// single compartment\n")
@@ -369,7 +371,7 @@ class NRNModelPoint():
                     cm = float(nrn.cm)
                     nf.write("\tcm = "+ str(cm).ljust(lj)+"// (uF/cm2)\n")
                 else:
-                    print "WARNING: memAreas other than \"0\" are not supported yet!!!"
+                    print("WARNING: memAreas other than \"0\" are not supported yet!!!")
 
                 # insert leak current
                 vdgs = nrn.vdgs
@@ -386,7 +388,7 @@ class NRNModelPoint():
                             if nrn.memAreaType == '0' or nrn.memAreaType == "":
                                 g = float(vdgs[vdgName].g) * 1.0e-6
                                 nf.write("\tg_pas = "+str(g).ljust(lj)+ "// (S/cm2)\n")
-                        
+
                 nf.write("}\n\n")
 
                 # write inital Vm
@@ -405,18 +407,18 @@ class NRNModelPoint():
                         try:
                             g = float(vdgs[vdgName].g)
                         except:
-                            print "WARNING!: could not convert "+vdgName+ " conductance of neuron " + nName
-                            print "Exited unexpectedly!"
+                            print("WARNING!: could not convert "+vdgName+ " conductance of neuron " + nName)
+                            print("Exited unexpectedly!")
                             sys.exit(-1)
 
                     if not self.useNrnPas:
                         if ivdType == '5':
                             nf.write("// passive current\n")
-                        
+
                             vdgObjName = nName+"_"+vdgName
                             nf.write("objref "+vdgObjName+ "\n")
                             nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_pas_ivd5(0.5)\n")
-                        
+
                             nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                             nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n\n\n")
                             continue
@@ -428,7 +430,7 @@ class NRNModelPoint():
                     if ivdType == '1' or ivdType == '3':
                         nf.write("//_A"+aType+"_B"+bType+"\n")
                         nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_tc_ivd"+ivdType+"_A"+aType+"(0.5)\n")
-                        
+
                         nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "p")+ "= "+vdgs[vdgName].P + "\n\n")
@@ -437,12 +439,12 @@ class NRNModelPoint():
 
                         if ivdType == '1':
                             self.write_InActF_timeConstant(nf,  vdgObjName, vdgs[vdgName])
-                        
+
                     if ivdType == '2' or ivdType == '4':
                         nf.write("//_m"+mType+"_h"+hType+"\n")
-                        
+
                         nf.write(nName+" "+vdgObjName+ " = new snnap_ionic_rc_ivd"+ivdType+"(0.5)\n")
-                        
+
                         nf.write(util.formatedObjectVar(vdgObjName, "e")+ "= "+(vdgs[vdgName].E).ljust(lj) + "// (mV)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "gmax") + "= " + str(g).ljust(lj) + "// (uS)\n")
                         nf.write(util.formatedObjectVar(vdgObjName, "p")+ "= "+vdgs[vdgName].P + "\n\n")
@@ -468,7 +470,7 @@ class NRNModelPoint():
         amType = ivd.amType
         file.write(util.formatedObjectVar(vdgObj, "am_type")+ "= "+ ivd.amType+ "\n")
         file.write(util.formatedObjectVar(vdgObj, "am_A")+ "= "+ ivd.am_A+ "\n")
-        
+
         if amType != '1':
             file.write(util.formatedObjectVar(vdgObj, "am_B")+ "= "+ (ivd.am_B).ljust(lj)+ "// (mV)\n")
 
@@ -478,21 +480,21 @@ class NRNModelPoint():
                 if amType != '5' and amType != '6' and amType != '7':
 
                     file.write(util.formatedObjectVar(vdgObj, "am_D")+ "= "+ (ivd.am_D).ljust(lj)+ "// (mV)\n")
-            
+
         bmType = ivd.bmType
         file.write("\n")
         file.write(util.formatedObjectVar(vdgObj, "bm_type")+ "= "+ bmType+ "\n")
         file.write(util.formatedObjectVar(vdgObj, "bm_A")+ "= "+ ivd.bm_A+ "\n")
-        
+
         if bmType != '1':
             file.write(util.formatedObjectVar(vdgObj, "bm_B")+ "= "+ (ivd.bm_B).ljust(lj)+ "// (mV)\n")
 
             if bmType != '4' and bmType != '8' and bmType != '9':
                 file.write(util.formatedObjectVar(vdgObj, "bm_C")+ "= "+ (ivd.bm_C).ljust(lj)+ "// (mV)\n")
-                
+
                 if bmType != '5' and bmType != '6' and bmType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "bm_D")+ "= "+ (ivd.bm_D).ljust(lj)+ "// (mV)\n")
-                    
+
         file.write("\n")
 
     def write_InActF_rateConstant(self, file, vdgObj, ivd):
@@ -517,7 +519,7 @@ class NRNModelPoint():
 
                 if ahType != '5' and ahType != '6' and ahType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "ah_D")+ "= "+ (ivd.ah_D).ljust(lj)+ "// (mV)\n")
-            
+
         bhType = ivd.bhType
         file.write("\n")
         file.write(util.formatedObjectVar(vdgObj, "bh_type")+ "= "+ bhType+ "\n")
@@ -525,10 +527,10 @@ class NRNModelPoint():
 
         if bhType != '1':
             file.write(util.formatedObjectVar(vdgObj, "bh_B")+ "= "+ (ivd.bh_B).ljust(lj)+ "// (mV)\n")
- 
+
             if bhType != '4' and bhType != '8' and bhType != '9':
                 file.write(util.formatedObjectVar(vdgObj, "bh_C")+ "= "+ (ivd.bh_C).ljust(lj)+ "// (mV)\n")
- 
+
                 if bhType != '5' and bhType != '6' and bhType != '7':
                     file.write(util.formatedObjectVar(vdgObj, "bh_D")+ "= "+ (ivd.bh_D).ljust(lj)+ "// (mV)\n")
         file.write("\n")
@@ -538,14 +540,14 @@ class NRNModelPoint():
         afType = ivd.AType
         if afType == "2":
             #file.write(util.formatedObjectVar(vdgObj, "A_IV")+ "= "+ ivd.A_IV+ "\n")
-            
+
             tAType = ivd.tAType
             file.write(util.formatedObjectVar(vdgObj, "tA_type")+ "= "+ tAType+ "\n")
 
             # convert seconds to ms
             tA_tx = float(ivd.tA_tx) * 1000.0
             file.write(util.formatedObjectVar(vdgObj, "tA_tx") + "= "+ str(tA_tx).ljust(lj)+ "// (ms)\n")
-            
+
             if tAType in ['2', '3', '6']:
                 file.write(util.formatedObjectVar(vdgObj, "tA_h1") + "= "+ (ivd.tA_h1).ljust(lj)+ "// (mV)\n")
                 file.write(util.formatedObjectVar(vdgObj, "tA_s1") + "= "+ (ivd.tA_s1).ljust(lj)+ "// (mV)\n")
@@ -560,12 +562,12 @@ class NRNModelPoint():
                     if tAType != '6':
                         file.write(util.formatedObjectVar(vdgObj, "tA_p2") + "= "+ (ivd.tA_p2).ljust(lj)+ "\n\n")
             elif tAType != '1':
-                print "WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!"
+                print("WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!")
 
         # write steady state
         ssAType = ivd.ssAType
         file.write(util.formatedObjectVar(vdgObj, "ssA_type") + "= "+ ssAType+ "\n")
-        
+
         file.write(util.formatedObjectVar(vdgObj, "ssA_h") + "= "+ (ivd.ssA_h).ljust(lj)+ "// (mV)\n")
         file.write(util.formatedObjectVar(vdgObj, "ssA_s") + "= "+ (ivd.ssA_s).ljust(lj)+ "// (mV)\n")
         file.write(util.formatedObjectVar(vdgObj, "ssA_p") + "= "+ ivd.ssA_p+ "\n")
@@ -580,7 +582,7 @@ class NRNModelPoint():
         inactfType = ivd.BType
         if inactfType == "2":
             #file.write(util.formatedObjectVar(vdgObj, "B_IV")+ "= "+ ivd.B_IV+ "\n")
-            
+
             tBType = ivd.tBType
             file.write(util.formatedObjectVar(vdgObj, "tB_type")+ "= "+ tBType+ "\n")
 
@@ -602,7 +604,7 @@ class NRNModelPoint():
                     if tBType != '6':
                         file.write(util.formatedObjectVar(vdgObj, "tB_p2")+ "= "+ ivd.tB_p2+ "\n\n")
             elif tBType != '1':
-                print "WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!"
+                print("WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!")
 
         # write steady state
         ssBType = ivd.ssBType
@@ -619,146 +621,146 @@ class NRNModelPoint():
         """
         print neuron data into stdout
         """
-        print "\n::: Neuron data :::"
+        print("\n::: Neuron data :::")
         for nName in sSim.network.neurons.keys():
-            print "Neuron Name: ", nName
+            print("Neuron Name: ", nName)
             nrn = sSim.network.neurons[nName]
-            print "treshold: ", nrn.treshold
-            print "spikeDur: ", nrn.spikeDur
-            print "vmInit: ", nrn.vmInit
-            print "cm: ", nrn.cm
-            print "memAreaType: ", nrn.memAreaType
+            print("treshold: ", nrn.treshold)
+            print("spikeDur: ", nrn.spikeDur)
+            print("vmInit: ", nrn.vmInit)
+            print("cm: ", nrn.cm)
+            print("memAreaType: ", nrn.memAreaType)
 
             for vdgName  in nrn.vdgs.keys():
                 vdg = nrn.vdgs[vdgName]
-                
-                print "---"+vdgName
+
+                print("---"+vdgName)
                 self.printIvd(vdg)
 
-            print ""
+            print("")
 
     def print_ActF_rateConstant(self, ivd):
         afType = ivd.mType
         if afType == "2" or afType == "3":
-            print "m_IV: ", ivd.m_IV            
+            print("m_IV: ", ivd.m_IV)
         if afType == "3":
-            print "m_L: ", ivd.m_L
+            print("m_L: ", ivd.m_L)
         amType = ivd.amType
-        print "amType: ", ivd.amType
-        print "am_A: ", ivd.am_A
+        print("amType: ", ivd.amType)
+        print("am_A: ", ivd.am_A)
         if amType != '1':
-            print "am_B: ", ivd.am_B
+            print("am_B: ", ivd.am_B)
         if amType != '4' and amType != '8' and amType != '9':
-            print "am_C: ", ivd.am_C
+            print("am_C: ", ivd.am_C)
         if amType != '5' and amType != '6' and amType != '7':
-            print "am_D: ", ivd.am_D
-            
+            print("am_D: ", ivd.am_D)
+
         bmType = ivd.bmType
-        print "bmType: ", ivd.bmType
-        print "bm_A: ", ivd.bm_A
+        print("bmType: ", ivd.bmType)
+        print("bm_A: ", ivd.bm_A)
         if bmType != '1':
-            print "bm_B: ", ivd.bm_B
+            print("bm_B: ", ivd.bm_B)
             if bmType != '4' and bmType != '8' and bmType != '9':
-                print "bm_C: ", ivd.bm_C
+                print("bm_C: ", ivd.bm_C)
                 if bmType != '5' and bmType != '6' and bmType != '7':
-                    print "bm_D: ", ivd.bm_D
+                    print("bm_D: ", ivd.bm_D)
 
     def print_InActF_rateConstant(self, ivd):
         inactfType = ivd.hType
         if inactfType == "2" or inactfType == "3":
-            print "h_IV: ", ivd.h_IV            
+            print("h_IV: ", ivd.h_IV)
         if inactfType == "3":
-            print "h_L: ", ivd.h_L
+            print("h_L: ", ivd.h_L)
         ahType = ivd.ahType
-        print "ahType: ", ahType
-        print "ah_A: ", ivd.ah_A
+        print("ahType: ", ahType)
+        print("ah_A: ", ivd.ah_A)
         if ahType != '1':
-            print "ah_B: ", ivd.ah_B
+            print("ah_B: ", ivd.ah_B)
         if ahType != '4' and ahType != '8' and ahType != '9':
-            print "ah_C: ", ivd.ah_C
+            print("ah_C: ", ivd.ah_C)
         if ahType != '5' and ahType != '6' and ahType != '7':
-            print "ah_D: ", ivd.ah_D
-            
+            print("ah_D: ", ivd.ah_D)
+
         bhType = ivd.bhType
-        print "bhType: ", ivd.bhType
-        print "bh_A: ", ivd.bh_A
+        print("bhType: ", ivd.bhType)
+        print("bh_A: ", ivd.bh_A)
         if bhType != '1':
-            print "bh_B: ", ivd.bh_B
+            print("bh_B: ", ivd.bh_B)
             if bhType != '4' and bhType != '8' and bhType != '9':
-                print "bh_C: ", ivd.bh_C
+                print("bh_C: ", ivd.bh_C)
                 if bhType != '5' and bhType != '6' and bhType != '7':
-                    print "bh_D: ", ivd.bh_D            
+                    print("bh_D: ", ivd.bh_D)
 
     def print_ActF_timeConstant(self, ivd):
         afType = ivd.AType
         if afType == "2":
-            print "A_IV: ", ivd.A_IV
+            print("A_IV: ", ivd.A_IV)
             tAType = ivd.tAType
-            print "+++tAType: ", tAType
-            print "tA_tx: ", ivd.tA_tx
+            print("+++tAType: ", tAType)
+            print("tA_tx: ", ivd.tA_tx)
             if tAType == '2':
-                print "tA_tn: ", ivd.tA_tn
-                print "tA_h1: ", ivd.tA_h1
-                print "tA_s1: ", ivd.tA_s1
-                print "tA_p1: ", ivd.tA_p1
+                print("tA_tn: ", ivd.tA_tn)
+                print("tA_h1: ", ivd.tA_h1)
+                print("tA_s1: ", ivd.tA_s1)
+                print("tA_p1: ", ivd.tA_p1)
 
             elif tAType != '1':
-                print "WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!"
-            
+                print("WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!")
+
         ssAType = ivd.ssAType
-        print "ssAType: ", ssAType
-        
-        print "ssA_h: ", ivd.ssA_h
-        print "ssA_s: ", ivd.ssA_s
-        print "ssA_p: ", ivd.ssA_p            
+        print("ssAType: ", ssAType)
+
+        print("ssA_h: ", ivd.ssA_h)
+        print("ssA_s: ", ivd.ssA_s)
+        print("ssA_p: ", ivd.ssA_p)
         if ssAType == 2:
-            print "ssA_IV: ", ivd.ssA_An
+            print("ssA_IV: ", ivd.ssA_An)
 
     def print_InActF_timeConstant(self, ivd):
         inactfType = ivd.BType
         if inactfType == "2":
-            print "B_IV: ", ivd.B_IV
-            
+            print("B_IV: ", ivd.B_IV)
+
             tBType = ivd.tBType
-            print "+++tBType: ", tBType
-            print "tB_tx: ", ivd.tB_tx
+            print("+++tBType: ", tBType)
+            print("tB_tx: ", ivd.tB_tx)
             if tBType == '2':
-                print "tB_tn: ", ivd.tB_tn
-                print "tB_h1: ", ivd.tB_h1
-                print "tB_s1: ", ivd.tB_s1
-                print "tB_p1: ", ivd.tB_p1
+                print("tB_tn: ", ivd.tB_tn)
+                print("tB_h1: ", ivd.tB_h1)
+                print("tB_s1: ", ivd.tB_s1)
+                print("tB_p1: ", ivd.tB_p1)
 
             elif tBType != '1':
-                print "WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!"
-            
+                print("WARNING: Time constant forms other than 1st or 2nd forms are not supported yet!!!")
+
         ssBType = ivd.ssBType
-        print "ssBType: ", ssBType
-        
-        print "ssB_h: ", ivd.ssB_h
-        print "ssB_s: ", ivd.ssB_s
-        print "ssB_p: ", ivd.ssB_p            
+        print("ssBType: ", ssBType)
+
+        print("ssB_h: ", ivd.ssB_h)
+        print("ssB_s: ", ivd.ssB_s)
+        print("ssB_p: ", ivd.ssB_p)
         if ssBType == 2:
-            print "ssB_IV: ", ivd.ssB_Bn
-            
+            print("ssB_IV: ", ivd.ssB_Bn)
+
     def printIvd(self, ivd):
         ivdType = ivd.ivdType
-        print "ivd type: ", ivdType
+        print("ivd type: ", ivdType)
         if ivdType == "1" or ivdType == "3":
-            print "------------------AType: ", ivd.AType
-            print "P: ", ivd.P
+            print("------------------AType: ", ivd.AType)
+            print("P: ", ivd.P)
             self.print_ActF_timeConstant(ivd)
 
         if ivdType == "2" or ivdType == "4":
-            print "mType: ", ivd.mType
-            print "P: ", ivd.P
+            print("mType: ", ivd.mType)
+            print("P: ", ivd.P)
             self.print_ActF_rateConstant(ivd)
 
         if ivdType == "1":
-            print "------------------BType: ", ivd.BType
+            print("------------------BType: ", ivd.BType)
             self.print_InActF_timeConstant(ivd)
 
         if ivdType == "2":
-            print "hType: ", ivd.hType
+            print("hType: ", ivd.hType)
             self.print_InActF_rateConstant(ivd)
-        print "E: ", ivd.E
-        print "g: ", ivd.g
+        print("E: ", ivd.E)
+        print("g: ", ivd.g)

--- a/nrnModelPoint.py
+++ b/nrnModelPoint.py
@@ -264,9 +264,9 @@ class NRNModelPoint():
 
         with open(rFileName, "w") as rf:
             rf.write("This is an automatically generated directory.\n")
-            rf.write("These scripts will allow you to recreate the results of "+self.simName+".smu in Neuron\n")
+            rf.write("These scripts will allow you to recreate the results of "+self.simName+".smu in NEURON\n")
             rf.write("Before running them, conpile the .mod files found in SNNAP2NERON/utilityfiles/snnap_modfiles\n")
-            rf.write("Then simply run file in this directory which is named sim_"+self.simName+".hoc in Neuron\n")
+            rf.write("Then simply run file in this directory which is named sim_"+self.simName+".hoc in NEURON\n")
             rf.write("\n")
             rf.write("More info here: https://github.com/madawa87/SNNAP2NEURON/tree/master")
 
@@ -341,7 +341,7 @@ class NRNModelPoint():
 
         if not os.path.isdir(self.nrnDirPath + os.sep + self.nrnDirName):
             os.mkdir(self.nrnDirPath + os.sep + self.nrnDirName)
-            print("Neuron model is located in ", self.nrnDirPath + os.sep + self.nrnDirName)
+            print("NEURON model is located in ", self.nrnDirPath + os.sep + self.nrnDirName)
 
     def writeNeurons(self, sSim):
         """
@@ -456,7 +456,7 @@ class NRNModelPoint():
                     nf.write("\n")
 
     def write_ActF_rateConstant(self, file, vdgObj, ivd):
-        # in SNNAP time derivatives are also in seconds. to convert them to Neuron time derivatives
+        # in SNNAP time derivatives are also in seconds. to convert them to NEURON time derivatives
         # must be divided by 1000.0
         lj = self.lJust1
         afType = ivd.mType

--- a/nrnModelPoint.py
+++ b/nrnModelPoint.py
@@ -36,7 +36,7 @@ class NRNModelPoint():
         self.useNrnPas = False
 
         self.neuronlist = {}
-        self.neutonFiles = []
+        self.neuronFiles = []
         self.chemSynFiles = []
         self.ElecCouplingFile = ""
         self.treatmentFile = None
@@ -280,7 +280,7 @@ class NRNModelPoint():
             mf.write("load_file(\"nrngui.hoc\")\n\n")
 
             mf.write("// create neurons\n")
-            for nfile in self .neutonFiles:
+            for nfile in self .neuronFiles:
                 mf.write("load_file(\"" +nfile+ "\")\n")
             mf.write("\n")
 
@@ -356,7 +356,7 @@ class NRNModelPoint():
 
             with open(nFileName, "w") as nf:
                 # append file name to the neuron filelist
-                self.neutonFiles.append(nf_local)
+                self.neuronFiles.append(nf_local)
 
                 nf.write("create "+ nName+"\n")
                 nf.write(nName + " {\n")

--- a/readS.py
+++ b/readS.py
@@ -53,10 +53,10 @@ if __name__ == "__main__":
     cond = ''
     if args.cond == 'p':
         cond = 'p'
-        print("Conductances will be as point mechanisms")
+        print("Conductances will be represented as point mechanisms")
     elif args.cond == 'd':
         cond = 'd'
-        print("Conductances will be as distributed mechanisms")
+        print("Conductances will be represented as distributed mechanisms")
     else:
         print("choises for --cond are either 'p' or 'd'")
 

--- a/readS.py
+++ b/readS.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         cond = 'd'
         print("Conductances will be represented as distributed mechanisms")
     else:
-        print("choises for --cond are either 'p' or 'd'")
+        print("choices for --cond are either 'p' or 'd'")
 
     # if len(sys.argv) > 1:
     #     filePath = sys.argv[1]

--- a/readS.py
+++ b/readS.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import re
 import os
@@ -26,7 +28,7 @@ from nrnModelPoint import NRNModelPoint
 from nrnModelDist import NRNModelDist
 
 def parse2Hoc(filename, cond):
-    # create simulation object. 
+    # create simulation object.
     snnapSim = sim(filename)
 
     # write model in NEURON
@@ -39,7 +41,7 @@ def parse2Hoc(filename, cond):
 def printSim(sim):
     pass
 
-    
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", help="path to SNNAP .smu file")
@@ -51,13 +53,13 @@ if __name__ == "__main__":
     cond = ''
     if args.cond == 'p':
         cond = 'p'
-        print "Conductances will be as point mechanisms"
+        print("Conductances will be as point mechanisms")
     elif args.cond == 'd':
         cond = 'd'
-        print "Conductances will be as distributed mechanisms"
+        print("Conductances will be as distributed mechanisms")
     else:
-        print "choises for --cond are either 'p' or 'd'"
-    
+        print("choises for --cond are either 'p' or 'd'")
+
     # if len(sys.argv) > 1:
     #     filePath = sys.argv[1]
     # else:
@@ -68,6 +70,5 @@ if __name__ == "__main__":
 
     simFilePath = splitedFilePath[:-1]
     simFileName = splitedFilePath[len(splitedFilePath)-1]
-    
-    currSim = parse2Hoc(filePath, cond)
 
+    currSim = parse2Hoc(filePath, cond)

--- a/simulation.py
+++ b/simulation.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import re
 import os
 import util
@@ -24,7 +26,7 @@ from treatment import Treatment as trt
 
 class Simulation ():
     def __init__(self, filePath):
-        
+
         """
         self.LOGICAL_NAME
         self.TIMING
@@ -49,18 +51,18 @@ class Simulation ():
 
         self.simFilePath = os.sep.join(splitedFilePath[:-1])
         self.simFileName = splitedFilePath[len(splitedFilePath)-1]
-    
+
         # read simulation(.smu) file
         self.readSimFile(self.simFilePath, self.simFileName)
 
         # read network(.ntw) file
         self.network = ntw(self.simFilePath, self.parameters['NETWORK'])
 
-        print "Done reading .ntw file"
+        print("Done reading .ntw file")
 
         if self.parameters['TREATMENTS'] != "":
             self.treatemts = trt(self.simFilePath, self.parameters['TREATMENTS'])
-    
+
     def readSimFile(self, filePath, fileName):
         """
         read simulation file
@@ -69,7 +71,7 @@ class Simulation ():
         with open(fileName) as f:
             self.text = f.read()
 
-            print "Reading simulaiton file : ", fileName
+            print("Reading simulaiton file : ", fileName)
             # extract useful lines from the the text
             lineArr = util.cleanupFileText(self.text)
 
@@ -90,7 +92,7 @@ class Simulation ():
         and return line number of the next parameter
         SNNAP states time in seconds in .smu file
         """
-        
+
         if word1 == "TIMING":
             self.parameters['TIMING']['t0']    = lineArr[i+1][0]
             self.parameters['TIMING']['tStop'] = lineArr[i+2][0]
@@ -99,4 +101,3 @@ class Simulation ():
         else:
             self.parameters[word1] = lineArr[i+1][0]
             return i+1
-

--- a/sm.py
+++ b/sm.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import os
 import re
@@ -36,7 +38,7 @@ class SMPool():
         self.tau = ''
 
         self.xCsmType = ''
-        
+
         self.readSMFile()
 
     def readSMFile(self):
@@ -47,9 +49,9 @@ class SMPool():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading second messenger file : ", filename
+            print("Reading second messenger file : ", filename)
             lineArr = util.cleanupFileText(self.text)
-            
+
             i = 0
             while i< len(lineArr):
                 line = lineArr[i]
@@ -90,4 +92,3 @@ class ConductanceBySM():
         # self.fBRType = ''
         # self.BRType = ''
         # self.BR_a = ''
-        

--- a/treatment.py
+++ b/treatment.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import sys
 import re
 import os
@@ -24,7 +26,7 @@ import util
 class CurrentInj():
     def __init__(self, nName, start, stop, magnitude):
         """
-        Current injection 
+        Current injection
         SNNAP .trt files contain time and magnitude in units of seconds
         and nA respectively
         """
@@ -36,7 +38,7 @@ class CurrentInj():
 class ModInj():
     def __init__(self, nName, mod, sm, start, stop, magnitude):
         """
-        Modulator injection: changes the availability of second messenger 
+        Modulator injection: changes the availability of second messenger
         concentration [MOD]
         """
         self.neuronName = nName
@@ -61,7 +63,7 @@ class Treatment():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading treatment file : ", filename
+            print("Reading treatment file : ", filename)
             lineArr = util.cleanupFileText(self.text)
 
             i = 0
@@ -78,7 +80,7 @@ class Treatment():
                 i = i+1
 
     def extractCurntInj(self, i, lineArr):
-        print "Reading current injections in .trt file"
+        print("Reading current injections in .trt file")
 
         while lineArr[i][0] != "END":
             if re.search("Name of Neuron", lineArr[i][1]) is not None:
@@ -89,11 +91,11 @@ class Treatment():
                 if float(magnitude) != 0.0:
                     self.currentInjList.append(CurrentInj(nrn, start, stop, magnitude))
             i = i+1
-        print "Found", len(self.currentInjList), "current injections."
+        print("Found", len(self.currentInjList), "current injections.")
         return i+1
 
     def extractModInj(self, i, lineArr):
-        print "Reading modulator injections in .trt file"
+        print("Reading modulator injections in .trt file")
 
         while lineArr[i][0] != "END":
             if re.search("Name of Neuron", lineArr[i][1]) is not None:
@@ -106,10 +108,10 @@ class Treatment():
 
                 # magnitude can be a .fnc file
                 if re.search("fnc", magnitude) is not None:
-                    print "WARNING: Modulator treatments by .fnc files are not supported yet!"
+                    print("WARNING: Modulator treatments by .fnc files are not supported yet!")
                     sys.exit()
                 if float(magnitude) != 0.0:
                     self.modInjList.append(ModInj(nrn, mod, sm, start, stop, magnitude))
             i = i+1
-        print "Found", len(self.currentInjList), "modulator injections."
+        print("Found", len(self.currentInjList), "modulator injections.")
         return i+1

--- a/util.py
+++ b/util.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import re
 import os
 
@@ -40,7 +42,7 @@ def cleanupFileText(text):
 
     Returns:
     lineArr - an array of lines without comments and empty lines
-    
+
     """
     fileLines = text.split('\n')
     lineArr = []
@@ -59,7 +61,7 @@ def findNextFeature(i, lineArr, feature=""):
     """
     if feature == "":
         return None
-        
+
     j = i+1
     if j >= len(lineArr):
         return None
@@ -74,7 +76,7 @@ def writePlottingFile(nrnDirPath, nrnDirName, sSim):
     """
     pf_local = "create_plot.hoc"
     if not os.path.isdir(nrnDirPath + os.sep + nrnDirName):
-        print "Failed to write "+ pf_local+" file"
+        print("Failed to write "+ pf_local+" file")
         return
 
     plotFileName = os.path.join(nrnDirPath,nrnDirName,pf_local)
@@ -83,10 +85,10 @@ def writePlottingFile(nrnDirPath, nrnDirName, sSim):
 // view: xmin, ymin, xrange, yrange, winleft, wintop, winwidth, winheight\n
 plots.view(0, -110, tstop, 210, 0, 290, 640, 320)\n
 //addvar: \"label\", \"variable\", color_index, brush_index\n"""
-    
+
     with open(plotFileName, "w") as pf:
         pf.write(plot_BP)
-        
+
         nNeurons = len(sSim.network.neurons.keys())
         if nNeurons > 3:
             nNeurons = 3
@@ -98,4 +100,3 @@ plots.view(0, -110, tstop, 210, 0, 290, 640, 320)\n
             nrn = sSim.network.neurons[nName]
             pf.write("plots.addvar(\"" +nName+ " Vm\", \""+nName+".v(0.5)\", "+str(i+2)+", 1)\n")
             i = i+1
-            

--- a/vdgConductance.py
+++ b/vdgConductance.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SNNAP2NEURON.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import re
 import os
 import util
@@ -66,7 +68,7 @@ class VDConductance():
         self.ssB_s = ""
         self.ssB_p = ""
         self.ssB_Bn = ""
-        
+
         self.tBType = ""
         self.tB_tx = ""
         self.tB_tn = ""
@@ -81,7 +83,7 @@ class VDConductance():
         self.mType = ""
         self.m_IV = ""
         self.m_L = ""
-        
+
         self.amType = ""
         self.am_A = ""
         self.am_B = ""
@@ -98,7 +100,7 @@ class VDConductance():
         self.hType = ""
         self.h_IV = ""
         self.h_L = ""
-        
+
         self.ahType = ""
         self.ah_A = ""
         self.ah_B = ""
@@ -110,7 +112,7 @@ class VDConductance():
         self.bh_B = ""
         self.bh_C = ""
         self.bh_D = ""
-        
+
         self.readVDGFile()
         if self.ivdType == "2" or self.ivdType == "4":
             self.read_mFile()
@@ -127,7 +129,7 @@ class VDConductance():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading .A file : ", filename
+            print("Reading .A file : ", filename)
             lineArr = util.cleanupFileText(self.text)
 
             i = 0
@@ -148,7 +150,7 @@ class VDConductance():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading .B file : ", filename
+            print("Reading .B file : ", filename)
             lineArr = util.cleanupFileText(self.text)
 
             i = 0
@@ -162,7 +164,7 @@ class VDConductance():
                     self.tBType, self.tB_tx, self.tB_tn, self.tB_h1, self.tB_h2, self.tB_s1, self.tB_s2, self.tB_p1, self.tB_p2  = self.extractTimeConstant(i+1, lineArr)
                 i = i+1
         return
-    
+
     def extractTimeConstant(self, i, lineArr):
         """
         read and return parameters related to time constant for activation (tA from .A files)
@@ -194,7 +196,7 @@ class VDConductance():
                 p1 = self.findNextFeature(i, lineArr, "p1")
                 p2 = self.findNextFeature(i, lineArr, "p2")
         elif tConstType != '1':
-            print "WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!"
+            print("WARNING: Time constant forms other than 1, 2, 3 or 6 are not supported yet!!!")
         return tConstType, tx, tn, h1, h2, s1, s2, p1, p2
 
     def extractSteadyState(self, i, lineArr, isActivation):
@@ -213,7 +215,7 @@ class VDConductance():
             ss_Xn= self.findNextFeature(i, lineArr, "An")
         if ssType == '2' and isActivation == 0:
             ss_Xn= self.findNextFeature(i, lineArr, "Bn")
-            
+
         ss_h = self.findNextFeature(i, lineArr, "h")
         ss_s = self.findNextFeature(i, lineArr, "s")
         ss_p = self.findNextFeature(i, lineArr, "p")
@@ -229,7 +231,7 @@ class VDConductance():
         funcType = lineArr[i][0]
         if funcType == "2":
             iv = self.findNextFeature(i, lineArr, "IV")
-            
+
         return funcType, iv
 
     def read_mFile(self):
@@ -237,7 +239,7 @@ class VDConductance():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading .m file : ", filename
+            print("Reading .m file : ", filename)
             lineArr = util.cleanupFileText(self.text)
 
             i = 0
@@ -252,13 +254,13 @@ class VDConductance():
 
                 i = i+1
         return
-    
+
     def read_hFile(self):
         filename = os.path.join(self.filePath,self.h)
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading .h file : ", filename
+            print("Reading .h file : ", filename)
             lineArr = util.cleanupFileText(self.text)
 
             i = 0
@@ -273,7 +275,7 @@ class VDConductance():
 
                 i = i+1
         return
-    
+
     def extractActivation_rateConst(self, i, lineArr):
         """
         extract rate constant activation (m) or inactivation (h) parameters
@@ -286,7 +288,7 @@ class VDConductance():
             iv = self.findNextFeature(i, lineArr, "IV")
         if funcType == "3":
             l = self.findNextFeature(i, lineArr, "L")
-            
+
         return funcType, iv, l
 
     def extractRateParameter(self, i, lineArr):
@@ -312,7 +314,7 @@ class VDConductance():
         with open(filename) as f:
             self.text = f.read()
 
-            print "Reading .vdg file : ", filename
+            print("Reading .vdg file : ", filename)
             lineArr = util.cleanupFileText(self.text)
 
             i = 0
@@ -347,11 +349,10 @@ class VDConductance():
     def findNextFeature(self, i, lineArr, feature=""):
         if feature == "":
             return None
-        
+
         j = i+1
         if j >= len(lineArr):
             return None
         while len(lineArr[j]) > 1 and re.search(feature, lineArr[j][1]) is None:
             j = j+1
         return lineArr[j][0]
-    


### PR DESCRIPTION
The only thing I found that was needed to make the code compatible with Python 3 was the addition of ``from __future__ import print_function`` and replacing each ``print ...`` statement with ``print(...)``. The tool now works for me both in Python 2 and 3.